### PR TITLE
Allow sending signals to processes inside a pot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - ifconfig: label and group interfaces created by pot (#206)
 - clone: add dns option, to customize DNS configuration while cloning (#199)
 - prepare: add -d option to change dns configuration during clone (#192)
+- signal: send signals to processes running inside a pot (#216)
 
 ### Changed
 - Stop logging trivial commands like get-rss to syslog by default (#190)

--- a/bin/pot
+++ b/bin/pot
@@ -138,6 +138,7 @@ usage() {
 	    prepare -- Import and prepare a pot, used by orchestrators
 	    update-config -- Update the configuration of a pot
 	    last-run-stats -- Get statistics about a pot's last run
+	    signal -- Send signal to pot
 	EOF
 }
 
@@ -193,7 +194,7 @@ case "${CMD}" in
 	start|stop|term|\
 	rename|clone|clone-fscomp|promote|\
 	snapshot|revert|purge-snapshots|update-config|\
-	last-run-stats)
+	last-run-stats|signal)
 		pot-cmd "${CMD}" "$@"
 		exit $?
 		;;

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -144,6 +144,15 @@ _is_absolute_path()
 	fi
 }
 
+# save encoded parameters suitable for use in `set --`
+_save_params () {
+	for i; do
+		printf %s\\n "$i" |\
+		sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/"
+	done
+	echo " "
+}
+
 # validate some values of the configuration files
 # $1 quiet / no _error messages are emitted
 _conf_check()

--- a/share/pot/signal.sh
+++ b/share/pot/signal.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# shellcheck disable=SC3033,SC3040,SC3043
+:
+
+signal-help()
+{
+	cat <<-"EOH"
+	pot signal [-hv] [-s signal] [-P pid] [-m pattern]-p pot
+	  -h print this help
+	  -v verbose
+	  -f : force - always returns success, even if no process could be killed
+	  -s signal : the symbolic name of the signal to send to the process,
+	              defaults to SIGINFO. Use `killall -l` to get a list of
+	              supported signals.
+	  -P pid : the pid inside the pot to send the signal to.
+	           for non-persistent pots this defaults to
+	           the pid of the main process
+          -m pattern : A pattern to match (overrides -P)
+	  -p pot : the pot image
+	EOH
+}
+
+pot-signal()
+{
+	local _pname _pid _match _signal _tmpfile _force _ret
+	_pname=
+	_pid=
+	_match=
+	_signal="SIGINFO"
+	_force="NO"
+	OPTIND=1
+	while getopts "hvfs:P:m:p:" _o ; do
+		case "$_o" in
+		h)
+			signal-help
+			${EXIT} 0
+			;;
+		v)
+			_POT_VERBOSITY=$(( _POT_VERBOSITY + 1))
+			;;
+		f)
+			_force="YES"
+			;;
+		s)
+			_signal="$OPTARG"
+			;;
+		P)
+			_pid="$OPTARG"
+			;;
+		m)
+			_match="$OPTARG"
+			;;
+		p)
+			_pname="$OPTARG"
+			;;
+		*)
+			signal-help
+			${EXIT} 1
+		esac
+	done
+
+	if [ -z "$_pname" ]; then
+		_error "A pot name is mandatory"
+		signal-help
+		${EXIT} 1
+	fi
+
+	if ! killall -l | xargs | tr ' ' '\n' |\
+	    sed 's/^\(.*\)$/\1\nSIG\1/g' | grep -qFx "$_signal"; then
+		_error "Invalid signal, valid signals: $(killall -l | xargs)"
+		${EXIT} 1		
+	fi
+
+	if [ -n "$_pid" ]; then
+		case "$_pid" in
+		''|*[!0-9]*)
+			_error "Invalid pid"
+			${EXIT} 1
+			;;
+		*)
+			;;
+		esac
+	fi
+
+	if ! _is_pot_running "$_pname" ; then
+		if [ "$_force" = "YES" ]; then
+			_info "The pot is not running"
+			return 0
+		fi
+		_error "The pot is not running"
+		${EXIT} 1
+	fi
+
+	if [ -n "$_match" ]; then
+		_info "Sending $_signal by pattern to pot $_pname"
+		pkill "-$_signal" -j "$_pname" "$_match"
+		_ret=$?
+	elif [ -n "$_pid" ]; then
+		_info "Sending $_signal to pid $_pid in pot $_pname"
+		_tmpfile=$(mktemp \
+		  "${POT_TMP:-/tmp}/pot_sigpid_${_pname}${POT_MKTEMP_SUFFIX}"
+		  ) || exit 1
+		echo "$_pid" >"$_tmpfile" || exit 1
+		pkill "-$_signal" -j "$_pname" -F "$_tmpfile"
+		_ret=$?
+		rm -f "$_tmpfile"
+	else
+		_info "Sending $_signal to main process of pot $_pname"
+		pkill "-$_signal" -j "$_pname" \
+		  -F "${POT_TMP:-/tmp}/pot_main_pid_${_pname}"
+		_ret=$?
+	fi
+
+	if [ $_ret -ne 0 ]; then
+		if [ "$_force" = "YES" ]; then
+			_info "Sending signal failed"
+			_ret=0
+		else
+			_error "Sending signal failed"
+		fi
+	fi
+
+	return $_ret
+}

--- a/share/pot/signal.sh
+++ b/share/pot/signal.sh
@@ -5,34 +5,143 @@
 signal-help()
 {
 	cat <<-"EOH"
-	pot signal [-hv] [-s signal] [-P pid] [-m pattern]-p pot
+	pot signal [-hvflC] [-s signal] [-P pid] [-m pattern] -p pot
 	  -h print this help
 	  -v verbose
-	  -f : force - always returns success, even if no process could be killed
+	  -C : check/dry-run: show processes that would match
+	  -f : force - always returns success, even if signalling failed
+	  -l : list supported signals
 	  -s signal : the symbolic name of the signal to send to the process,
-	              defaults to SIGINFO. Use `killall -l` to get a list of
-	              supported signals.
-	  -P pid : the pid inside the pot to send the signal to.
-	           for non-persistent pots this defaults to
-	           the pid of the main process
-          -m pattern : A pattern to match (overrides -P)
+	              defaults to SIGINFO
+	  -P pid : the pid inside the pot to send the signal to
+	  -m pattern : A pattern to match
 	  -p pot : the pot image
+
+	  Parameters -P and -m are mutually exclusive. If neither of them is
+	  is specified and the pot is non-persistent, the signal is delivered
+	  to the main process of the pot.
+
+	  For persistent pots, specifying one of -P and -m is mandatory.
 	EOH
+}
+
+# Get a list of supported signal names
+_get_signal_names()
+{
+	killall -l | xargs
+}
+
+# Validate if symbolic signal name is supported
+_validate_signal_name()
+{
+	local _signame
+	_signame="$1"
+
+	if ! _get_signal_names | xargs | tr ' ' '\n' |\
+	    sed 's/^\(.*\)$/\1\nSIG\1/g' | grep -qFx "$_signame"; then
+		return 1
+	fi
+}
+
+# Validate if a pid is syntactically acceptable
+_validate_pid()
+{
+	case "$_pid" in
+	''|*[!0-9]*)
+		return 1
+		;;
+	*)
+		;;
+	esac
+}
+
+# Actually send signal to process inside pot
+# $1 pot name
+# $2 signal
+# $3 pid
+# $4 match
+# $5 force (YES/NO)
+# $6 dry-run (YES/NO)
+_send_signal()
+{
+	local _pname _signal _pid _match _force _dry_run
+	local _cmd _tmpfile _persist _ret
+
+	_pname="$1"
+	_signal="$2"
+	_pid="$3"
+	_match="$4"
+	_force="$5"
+	_dry_run="$6"
+
+	if [ "$_dry_run" = "YES" ]; then
+		_cmd=$(_save_params "pgrep")
+	else
+		_cmd=$(_save_params "pkill" "-$_signal")
+	fi
+
+	# load kill command into $@
+	eval "set -- $_cmd"
+
+	if [ -n "$_match" ]; then
+		_info "Sending $_signal by pattern to pot $_pname"
+		"$@" -j "$_pname" "$_match"
+		_ret=$?
+	elif [ -n "$_pid" ]; then
+		_info "Sending $_signal to pid $_pid in pot $_pname"
+		_tmpfile=$(mktemp \
+		  "${POT_TMP:-/tmp}/pot_sigpid_${_pname}${POT_MKTEMP_SUFFIX}"
+		  ) || ${EXIT} 1
+		echo "$_pid" >"$_tmpfile" || ${EXIT} 1
+		"$@" -j "$_pname" -F "$_tmpfile"
+		_ret=$?
+		rm -f "$_tmpfile"
+	else
+		_info "Sending $_signal to main process of pot $_pname"
+		_persist="$(_get_conf_var "$_pname" "pot.attr.persistent")"
+		if [ "$_persist" != "NO" ]; then
+			if [ "$_force" = "YES" ]; then
+				_info "Persistent pots have no main process"
+				return 0
+			else
+				_error "Persistent pots have no main process"
+				return 1
+			fi
+		fi
+		"$@" -j "$_pname" -F "${POT_TMP:-/tmp}/pot_main_pid_${_pname}"
+		_ret=$?
+	fi
+
+	if [ $_ret -ne 0 ]; then
+		if [ "$_force" = "YES" ]; then
+			_info "Sending signal failed"
+			_ret=0
+		else
+			_error "Sending signal failed"
+		fi
+	fi
+
+	return $_ret
 }
 
 pot-signal()
 {
-	local _pname _pid _match _signal _tmpfile _force _ret
+	local _pname _signal _pid _match _force _dry_run
 	_pname=
 	_pid=
 	_match=
 	_signal="SIGINFO"
 	_force="NO"
+	_dry_run="NO"
 	OPTIND=1
-	while getopts "hvfs:P:m:p:" _o ; do
+	while getopts "hvflCs:P:m:p:" _o ; do
 		case "$_o" in
 		h)
 			signal-help
+			${EXIT} 0
+			;;
+		l)
+			_get_signal_names
 			${EXIT} 0
 			;;
 		v)
@@ -40,6 +149,9 @@ pot-signal()
 			;;
 		f)
 			_force="YES"
+			;;
+		C)
+			_dry_run="YES"
 			;;
 		s)
 			_signal="$OPTARG"
@@ -65,21 +177,19 @@ pot-signal()
 		${EXIT} 1
 	fi
 
-	if ! killall -l | xargs | tr ' ' '\n' |\
-	    sed 's/^\(.*\)$/\1\nSIG\1/g' | grep -qFx "$_signal"; then
-		_error "Invalid signal, valid signals: $(killall -l | xargs)"
-		${EXIT} 1		
+	if ! _validate_signal_name "$_signal"; then
+		_error "Invalid signal, valid signals: $(_get_signal_names)"
+		${EXIT} 1
 	fi
 
-	if [ -n "$_pid" ]; then
-		case "$_pid" in
-		''|*[!0-9]*)
-			_error "Invalid pid"
-			${EXIT} 1
-			;;
-		*)
-			;;
-		esac
+	if [ -n "$_pid" ] && [ -n "$_match" ]; then
+		_error "Process ID and pattern match are mutually exclusive"
+		${EXIT} 1
+	fi
+
+	if [ -n "$_pid" ] && ! _validate_pid "$_pid"; then
+		_error "Invalid pid"
+		${EXIT} 1
 	fi
 
 	if ! _is_pot_running "$_pname" ; then
@@ -91,34 +201,5 @@ pot-signal()
 		${EXIT} 1
 	fi
 
-	if [ -n "$_match" ]; then
-		_info "Sending $_signal by pattern to pot $_pname"
-		pkill "-$_signal" -j "$_pname" "$_match"
-		_ret=$?
-	elif [ -n "$_pid" ]; then
-		_info "Sending $_signal to pid $_pid in pot $_pname"
-		_tmpfile=$(mktemp \
-		  "${POT_TMP:-/tmp}/pot_sigpid_${_pname}${POT_MKTEMP_SUFFIX}"
-		  ) || exit 1
-		echo "$_pid" >"$_tmpfile" || exit 1
-		pkill "-$_signal" -j "$_pname" -F "$_tmpfile"
-		_ret=$?
-		rm -f "$_tmpfile"
-	else
-		_info "Sending $_signal to main process of pot $_pname"
-		pkill "-$_signal" -j "$_pname" \
-		  -F "${POT_TMP:-/tmp}/pot_main_pid_${_pname}"
-		_ret=$?
-	fi
-
-	if [ $_ret -ne 0 ]; then
-		if [ "$_force" = "YES" ]; then
-			_info "Sending signal failed"
-			_ret=0
-		else
-			_error "Sending signal failed"
-		fi
-	fi
-
-	return $_ret
+	_send_signal "$_pname" "$_signal" "$_pid" "$_match" "$_force" "$_dry_run"
 }

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -559,6 +559,7 @@ _js_start()
 	fi
 
 	rm -f "${POT_TMP:-/tmp}/pot_stopped_${_pname}"
+	rm -f "${POT_TMP:-/tmp}/pot_main_pid_${_pname}"
 
 	_info "Starting the pot $_pname"
 	# shellcheck disable=SC2086
@@ -591,12 +592,17 @@ _js_start()
 	sleep 0.5
 	pkill -f -j "$_pname" "^sleep 1234$"
 
+        if [ "$_persist" = "NO" ]; then
+		echo "$_wait_pid" >"${POT_TMP:-/tmp}/pot_main_pid_${_pname}"
+	fi
+
 	wait "$_wait_pid"
 	_exit_code=$?
 
 	echo "{ \"ExitCode\": $_exit_code }" > "$_confdir/.last_run_stats"
 
 	if [ "$_persist" = "NO" ]; then
+		rm -f "${POT_TMP:-/tmp}/pot_main_pid_${_pname}"
 		# non-persistent jails always need to die
 		if [ ! -e "${POT_TMP:-/tmp}/pot_stopped_${_pname}" ]; then
 			start-cleanup "$_pname" "${_iface}"

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -592,7 +592,7 @@ _js_start()
 	sleep 0.5
 	pkill -f -j "$_pname" "^sleep 1234$"
 
-        if [ "$_persist" = "NO" ]; then
+	if [ "$_persist" = "NO" ]; then
 		echo "$_wait_pid" >"${POT_TMP:-/tmp}/pot_main_pid_${_pname}"
 	fi
 


### PR DESCRIPTION
`pot signal` allows sending signals to processes running inside a pot.

Non-persistent pots will receive the signal by default on their
main process (the one started by `pot start`), non-persistent pots can
still receive signals as specified by either `-P pid` or `-m pattern`.

Example of use:

    pot signal -s KILL -p mypot
    pot signal -p mypot -f -m "sleep"