### PR TITLE
Unit tests: Make monitor work in subshells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - prune: add flag "-g" to delay pruning of pots that just stopped, so users have a chance to inspect last-run-stats (#200)
 - help: rework usage screens (#209)
 - prepare: enable attribute no-tmpfs and no-etc-hosts (#192)
+- tests: improved monitoring of tests, requires sysutils/flock on FreeBSD (#220)
 
 ### Fixed
 - start: correct invocation of prestart and poststart hooks (#200)

--- a/tests/add-dep1.sh
+++ b/tests/add-dep1.sh
@@ -23,95 +23,93 @@ test_pot_add_dep_001()
 {
 	pot-add-dep
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 
 	setUp
 	pot-add-dep -vb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 
 	setUp
 	pot-add-dep -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 
 	setUp
 	pot-add-dep -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 }
 
 test_pot_add_dep_002()
 {
 	pot-add-dep -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 
 	setUp
 	pot-add-dep -P test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 
 	setUp
 	pot-add-dep -P test-pot -p test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 
 	setUp
 	pot-add-dep -p test-pot -P test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "2" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "2" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 
 	setUp
 	pot-add-dep -P test-pot -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "0" "$ADDDEP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "0" ADDDEP_CALLS
 }
 
 test_pot_add_dep_020()
 {
 	pot-add-dep -P test-pot -p test-pot-2
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "2" "$ISPOT_CALLS"
-	assertEquals "_add_dependency calls" "1" "$ADDDEP_CALLS"
-	assertEquals "pot name " "test-pot-2" "${ADDDEP_CALL1_ARG1}"
-	assertEquals "run time dependency" "test-pot" "${ADDDEP_CALL1_ARG2}"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "2" ISPOT_CALLS
+	assertEqualsMon "_add_dependency calls" "1" ADDDEP_CALLS
+	assertEqualsMon "pot name " "test-pot-2" ADDDEP_CALL1_ARG1
+	assertEqualsMon "run time dependency" "test-pot" ADDDEP_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	ADDDEP_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/clone-fscomp1.sh
+++ b/tests/clone-fscomp1.sh
@@ -36,95 +36,92 @@ test_pot_add_fscomp_001()
 {
 	pot-clone-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-clone-fscomp -vb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-clone-fscomp -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-clone-fscomp -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_add_fscomp_002()
 {
 	pot-clone-fscomp -f new-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cf_zfs calls" "0" "$CFZFS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cf_zfs calls" "0" CFZFS_CALLS
 
 	setUp
 	pot-clone-fscomp -F test-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cf_zfs calls" "0" "$CFZFS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cf_zfs calls" "0" CFZFS_CALLS
 }
 
 test_pot_add_fscomp_003()
 {
 	pot-clone-fscomp -f new-fscomp -F test-no-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "2" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cf_zfs calls" "0" "$CFZFS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "2" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cf_zfs calls" "0" CFZFS_CALLS
 
 	setUp
 	pot-clone-fscomp -f test-fscomp2 -F test-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "1" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cf_zfs calls" "0" "$CFZFS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "1" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cf_zfs calls" "0" CFZFS_CALLS
 }
 
 test_pot_add_fscomp_020()
 {
 	pot-clone-fscomp -f new-fscomp -F test-fscomp
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "2" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cf_zfs calls" "1" "$CFZFS_CALLS"
-	assertEquals "_cf_zfs arg1" "new-fscomp" "$CFZFS_CALL1_ARG1"
-	assertEquals "_cf_zfs arg2" "test-fscomp" "$CFZFS_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "2" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cf_zfs calls" "1" CFZFS_CALLS
+	assertEqualsMon "_cf_zfs arg1" "new-fscomp" CFZFS_CALL1_ARG1
+	assertEqualsMon "_cf_zfs arg2" "test-fscomp" CFZFS_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	ZDSET_CALLS=0
-	HELP_CALLS=0
-	CFZFS_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/clone1.sh
+++ b/tests/clone1.sh
@@ -76,96 +76,96 @@ test_pot_clone_001()
 {
 	pot-clone
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-clone -vL
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-clone -L bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-clone -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-clone -S
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_002()
 {
 	pot-clone -p new-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-clone -P test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_003()
 {
 	pot-clone -p new-pot -P no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-clone -p test-pot -P test-pot-2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_004()
@@ -173,11 +173,11 @@ test_pot_clone_004()
 	# missing -i parameter when needed
 	pot-clone -p new-pot -P test-pot-3
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_006()
@@ -185,11 +185,11 @@ test_pot_clone_006()
 	# ip address already in use
 	pot-clone -p new-pot -P test-pot-2 -i 10.1.2.3
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_007()
@@ -197,242 +197,237 @@ test_pot_clone_007()
 	# invalid pot name
 	pot-clone -p new.pot -P test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_020()
 {
 	pot-clone -p new-pot -P test-pot-0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_021()
 {
 	pot-clone -p new-pot -P test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "test-pot" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "NO" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "test-pot" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "NO" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_022()
 {
 	pot-clone -p new-pot-2 -P test-pot-2 -i 10.1.2.4
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg0" "new-pot-2" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg1" "test-pot-2" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot-2" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot-2" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.2.4" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg0" "new-pot-2" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg1" "test-pot-2" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot-2" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot-2" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.2.4" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_023()
 {
 	pot-clone -p new-pot -P test-pot -F
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "test-pot" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "YES" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "test-pot" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "YES" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_024()
 {
 	pot-clone -p new-pot-2 -P test-pot-2 -i auto
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg0" "new-pot-2" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg1" "test-pot-2" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot-2" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot-2" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.123.123.123" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg0" "new-pot-2" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg1" "test-pot-2" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot-2" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot-2" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.123.123.123" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_040()
 {
 	pot-clone -p new-pot-single -P test-pot-single -i auto
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg0" "new-pot-single" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg1" "test-pot-single" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot-single" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot-single" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.123.123.123" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg0" "new-pot-single" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg1" "test-pot-single" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot-single" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot-single" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.123.123.123" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_041()
 {
 	pot-clone -p new-pot-single -P test-pot-single -f flop
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg0" "new-pot-single" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg1" "test-pot-single" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot-single" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot-single" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.123.123.123" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "1" "$EXEC_FLV_CALLS"
-	assertEquals "_exec_flv arg1" "new-pot-single" "$EXEC_FLV_CALL1_ARG1"
-	assertEquals "_exec_flv arg2" "flop" "$EXEC_FLV_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg0" "new-pot-single" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg1" "test-pot-single" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot-single" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot-single" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.123.123.123" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "1" EXEC_FLV_CALLS
+	assertEqualsMon "_exec_flv arg1" "new-pot-single" EXEC_FLV_CALL1_ARG1
+	assertEqualsMon "_exec_flv arg2" "flop" EXEC_FLV_CALL1_ARG2
 }
 
 test_pot_clone_041()
 {
 	pot-clone -p new-pot-single -P test-pot-single -f flip -f flop
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg0" "new-pot-single" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg1" "test-pot-single" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot-single" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot-single" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.123.123.123" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "2" "$EXEC_FLV_CALLS"
-	assertEquals "_exec_flv arg1" "new-pot-single" "$EXEC_FLV_CALL1_ARG1"
-	assertEquals "_exec_flv arg2" "flip" "$EXEC_FLV_CALL1_ARG2"
-	assertEquals "_exec_flv arg1" "new-pot-single" "$EXEC_FLV_CALL2_ARG1"
-	assertEquals "_exec_flv arg2" "flop" "$EXEC_FLV_CALL2_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg0" "new-pot-single" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg1" "test-pot-single" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot-single" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot-single" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.123.123.123" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "2" EXEC_FLV_CALLS
+	assertEqualsMon "_exec_flv arg1" "new-pot-single" EXEC_FLV_CALL1_ARG1
+	assertEqualsMon "_exec_flv arg2" "flip" EXEC_FLV_CALL1_ARG2
+	assertEqualsMon "_exec_flv arg1" "new-pot-single" EXEC_FLV_CALL2_ARG1
+	assertEqualsMon "_exec_flv arg2" "flop" EXEC_FLV_CALL2_ARG2
 }
 
 test_pot_clone_060()
 {
 	pot-clone -p new-pot-public -P test-pot-multi-private -N public-bridge
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg0" "new-pot-public" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg1" "test-pot-multi-private" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot-public" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot-multi-private" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.123.123.123" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg0" "new-pot-public" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg1" "test-pot-multi-private" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot-public" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot-multi-private" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.123.123.123" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_061()
 {
 	pot-clone -p new-pot-private -P test-pot-multi-private -N private-bridge -B test-bridge
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg0" "new-pot-private" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg1" "test-pot-multi-private" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot-private" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot-multi-private" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "private-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.3.4" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "test-bridge" "$CJCONF_CALL1_ARG5"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg0" "new-pot-private" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg1" "test-pot-multi-private" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot-private" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot-multi-private" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "private-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.3.4" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "test-bridge" CJCONF_CALL1_ARG5
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_062()
 {
 	pot-clone -p new-pot-private -P test-pot-3 -N private-bridge -B test-bridge
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg0" "new-pot-private" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg1" "test-pot-3" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot-private" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot-3" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "private-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.3.4" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "test-bridge" "$CJCONF_CALL1_ARG5"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg0" "new-pot-private" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg1" "test-pot-3" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot-private" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot-3" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "private-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.3.4" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "test-bridge" CJCONF_CALL1_ARG5
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_clone_080()
 {
 	pot-clone -p new-pot -P test-pot -s 12345678
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "test-pot" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "NO" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "12345678" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "test-pot" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "test-pot" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "NO" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "12345678" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "test-pot" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 setUp()
 {
 	common_setUp
-	CJZFS_CALLS=0
-	CJCONF_CALLS=0
-	CJCONF_CALL1_ARG4=
-	HELP_CALLS=0
-	EXEC_FLV_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/clone2.sh
+++ b/tests/clone2.sh
@@ -78,187 +78,181 @@ test_cj_zfs_001()
 {
 	_cj_zfs new-pot test-pot NO
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "3" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "2" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL2_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/usr.local" "$ZFS_CALL2_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/usr.local@4321" "$ZFS_CALL2_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" "$ZFS_CALL2_ARG5"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" "$ZFS_CALL3_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@4321" "$ZFS_CALL3_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" "$ZFS_CALL3_ARG5"
+	assertEqualsMon "zfs calls" "3" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir c1 arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir c2 arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL2_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/usr.local" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/usr.local@4321" ZFS_CALL2_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" ZFS_CALL2_ARG5
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@4321" ZFS_CALL3_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG5
 }
 
 test_cj_zfs_002()
 {
 	_cj_zfs new-pot test-pot-2 NO
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "2" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "2" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL2_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" "$ZFS_CALL2_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-2/custom@4321" "$ZFS_CALL2_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" "$ZFS_CALL2_ARG5"
+	assertEqualsMon "zfs calls" "2" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir c1 arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir c2 arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL2_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-2/custom@4321" ZFS_CALL2_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL2_ARG5
 }
 
 test_cj_zfs_003()
 {
 	_cj_zfs new-pot test-pot YES
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "3" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "2" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL2_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/usr.local" "$ZFS_CALL2_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/usr.local@4321" "$ZFS_CALL2_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" "$ZFS_CALL2_ARG5"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" "$ZFS_CALL3_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@4321" "$ZFS_CALL3_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" "$ZFS_CALL3_ARG5"
+	assertEqualsMon "zfs calls" "3" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir c1 arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir c2 arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL2_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/usr.local" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/usr.local@4321" ZFS_CALL2_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" ZFS_CALL2_ARG5
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@4321" ZFS_CALL3_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG5
 }
 
 test_cj_zfs_004()
 {
 	_cj_zfs new-pot test-pot-2 YES
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "2" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "2" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL2_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" "$ZFS_CALL2_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-2/custom@4321" "$ZFS_CALL2_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" "$ZFS_CALL2_ARG5"
+	assertEqualsMon "zfs calls" "2" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir c1 arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir c2 arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL2_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-2/custom@4321" ZFS_CALL2_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL2_ARG5
 }
 
 test_cj_zfs_005()
 {
 	_cj_zfs new-pot test-pot-nosnap YES
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "5" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "2" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL2_ARG2"
-	assertEquals "zfs arg1" "snapshot" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/usr.local@55555" "$ZFS_CALL2_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL3_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/usr.local" "$ZFS_CALL3_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/usr.local@55555" "$ZFS_CALL3_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" "$ZFS_CALL3_ARG5"
-	assertEquals "zfs arg1" "snapshot" "$ZFS_CALL4_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/custom@55555" "$ZFS_CALL4_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL5_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" "$ZFS_CALL5_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/custom@55555" "$ZFS_CALL5_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" "$ZFS_CALL5_ARG5"
+	assertEqualsMon "zfs calls" "5" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir c1 arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir c2 arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL2_ARG2
+	assertEqualsMon "zfs arg1" "snapshot" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/usr.local@55555" ZFS_CALL2_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL3_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/usr.local" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/usr.local@55555" ZFS_CALL3_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" ZFS_CALL3_ARG5
+	assertEqualsMon "zfs arg1" "snapshot" ZFS_CALL4_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/custom@55555" ZFS_CALL4_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL5_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL5_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/custom@55555" ZFS_CALL5_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL5_ARG5
 }
 
 test_cj_zfs_020()
 {
 	_cj_zfs new-pot test-pot-nosnap NO
 	assertNotEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "1" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "undo_clone calls" "1" "$UNDO_CLONE_CALLS"
+	assertEqualsMon "zfs calls" "1" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "undo_clone calls" "1" UNDO_CLONE_CALLS
 }
 
 test_cj_zfs_040()
 {
 	_cj_zfs new-pot test-pot-single NO
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "2" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/m" "$ZFS_CALL2_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single/m@6688" "$ZFS_CALL2_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" "$ZFS_CALL2_ARG5"
+	assertEqualsMon "zfs calls" "2" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single/m@6688" ZFS_CALL2_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG5
 }
 
 test_cj_zfs_041()
 {
 	_cj_zfs new-pot test-pot-single-run NO
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "2" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/m" "$ZFS_CALL2_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single-run/m@6688" "$ZFS_CALL2_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" "$ZFS_CALL2_ARG5"
+	assertEqualsMon "zfs calls" "2" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single-run/m@6688" ZFS_CALL2_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG5
 }
 
 test_cj_zfs_060()
 {
 	_cj_zfs new-pot test-pot-single NO 12345678
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "2" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/m" "$ZFS_CALL2_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single/m@12345678" "$ZFS_CALL2_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" "$ZFS_CALL2_ARG5"
-	assertEquals "zfs last snap calls" "0" "$ZFSLASTSNAP_CALLS"
+	assertEqualsMon "zfs calls" "2" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single/m@12345678" ZFS_CALL2_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG5
+	assertEqualsMon "zfs last snap calls" "0" ZFSLASTSNAP_CALLS
 }
 
 test_cj_zfs_061()
 {
 	_cj_zfs new-pot test-pot NO 12345678
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "3" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "2" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL2_ARG2"
-	assertEquals "zfs arg1" "clone" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/usr.local" "$ZFS_CALL2_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/usr.local@12345678" "$ZFS_CALL2_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" "$ZFS_CALL2_ARG5"
-	assertEquals "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" "$ZFS_CALL3_ARG3"
-	assertEquals "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@12345678" "$ZFS_CALL3_ARG4"
-	assertEquals "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" "$ZFS_CALL3_ARG5"
-	assertEquals "zfs last snap calls" "0" "$ZFSLASTSNAP_CALLS"
+	assertEqualsMon "zfs calls" "3" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir c1 arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir c2 arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL2_ARG2
+	assertEqualsMon "zfs arg1" "clone" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/usr.local" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/usr.local@12345678" ZFS_CALL2_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" ZFS_CALL2_ARG5
+	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@12345678" ZFS_CALL3_ARG4
+	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG5
+	assertEqualsMon "zfs last snap calls" "0" ZFSLASTSNAP_CALLS
 }
 
 setUp()
 {
 	common_setUp
 	conf_setUp
-	ZFS_CALLS=0
-	ECHO_CALLS=0
-	MKDIR_CALLS=0
-	DATE_CALLS=0
-	ZFSDATASETVALID_CALLS=0
-	ZFSLASTSNAP_CALLS=0
-	UNDO_CLONE_CALLS=0
 }
 
 tearDown()
 {
+	common_tearDown
 	conf_tearDown
 }
 

--- a/tests/common-flv1.sh
+++ b/tests/common-flv1.sh
@@ -81,7 +81,13 @@ test_is_flavour_001()
 
 setUp()
 {
+	__mon_init
 	_POT_VERBOSITY=1
+}
+
+tearDown()
+{
+	__mon_tearDown
 }
 
 . shunit/shunit2

--- a/tests/common-stub.sh
+++ b/tests/common-stub.sh
@@ -300,7 +300,7 @@ _is_valid_release()
 	   *)
 		   return 1 # false
 		   ;;
-   esac
+	esac
 }
 
 _is_valid_netif()
@@ -351,23 +351,18 @@ _get_bridge_var()
 
 common_setUp()
 {
+	__mon_init
 	_POT_VERBOSITY=1
 	POT_DNS_NAME=dns
-	ERROR_CALLS=0
-	INFO_CALLS=0
-	DEBUG_CALLS=0
-	ISUID0_CALLS=0
-	ISPOT_CALLS=0
-	ISPOTRUN_CALLS=0
-	ISBASE_CALLS=0
-	ISFSCOMP_CALLS=0
-	GETCONFVAR_CALLS=0
-	GETPOTBASE_CALLS=0
-	ZFSEXIST_CALLS=0
-	POTZFSSNAP_CALLS=0
-	RMVPOTSNAP_CALLS=0
-	POTZFSSNAPFULL_CALLS=0
-	FSCOMPZFSSNAP_CALLS=0
-	RMVFSCOMPSNAP_CALLS=0
-	GETBRIDGEVAR_CALLS=0
+}
+
+common_tearDown()
+{
+	__mon_tearDown
+}
+
+# can be overridden by tests
+tearDown()
+{
+	common_tearDown
 }

--- a/tests/common-zfs2.sh
+++ b/tests/common-zfs2.sh
@@ -21,21 +21,28 @@ date()
 test_fscomp_zfs_snap_001()
 {
 	_fscomp_zfs_snap fscomp_name
-	assertEquals "zfs calls" "1" "$ZFS_CALLS"
-	assertEquals "zfs args" "/zroot/fscomp/fscomp_name@123454321" "$ZFS_CALL1_ARG2"
+	assertEqualsMon "zfs calls" "1" ZFS_CALLS
+	assertEqualsMon "zfs args" "/zroot/fscomp/fscomp_name@123454321" ZFS_CALL1_ARG2
 }
 
 test_fscomp_zfs_snap_002()
 {
 	# the argument "new_snap" is ignored
 	_fscomp_zfs_snap fscomp_name new_snap
-	assertEquals "zfs calls" "1" "$ZFS_CALLS"
-	assertEquals "zfs args" "/zroot/fscomp/fscomp_name@123454321" "$ZFS_CALL1_ARG2"
+	assertEqualsMon "zfs calls" "1" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "snapshot" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "/zroot/fscomp/fscomp_name@123454321" ZFS_CALL1_ARG2
 }
 
 setUp()
 {
-	ZFS_CALLS=0
+	__mon_init
 	POT_ZFS_ROOT=/zroot
 }
+
+tearDown()
+{
+	__mon_tearDown
+}
+
 . shunit/shunit2

--- a/tests/common1.sh
+++ b/tests/common1.sh
@@ -150,15 +150,15 @@ test_is_mounted()
 test_umount()
 {
 	_umount
-	assertEquals "0" "$UMOUNT_CALLS"
+	assertEqualsMon "umount calls1" "0" UMOUNT_CALLS
 
 	_umount /path/to/the/error
-	assertEquals "0" "$UMOUNT_CALLS"
+	assertEqualsMon "umount calls2" "0" UMOUNT_CALLS
 
 	_umount /opt/distfiles
-	assertEquals "1" "$UMOUNT_CALLS"
-	assertEquals "-f" "$UMOUNT_CALL1_ARG1"
-	assertEquals "/opt/distfiles" "$UMOUNT_CALL1_ARG2"
+	assertEqualsMon "umount calls3" "1" UMOUNT_CALLS
+	assertEqualsMon "umount c1 arg1" "-f" UMOUNT_CALL1_ARG1
+	assertEqualsMon "umount c1 arg2" "/opt/distfiles" UMOUNT_CALL1_ARG2
 }
 
 test_is_rctl_available()
@@ -200,12 +200,16 @@ test_is_absolute_path()
 
 setUp()
 {
+	__mon_init
 	_POT_VERBOSITY=1
-	UMOUNT_CALLS=0
 	SYSCTL_OUTPUT="1"
 	SYSCTL_RC=0
 	WHICH_POTNET_FAIL="NO"
-	FETCH_CALLS=0
+}
+
+tearDown()
+{
+	__mon_tearDown
 }
 
 . shunit/shunit2

--- a/tests/common4.sh
+++ b/tests/common4.sh
@@ -64,9 +64,14 @@ test_is_init_020()
 
 setUp()
 {
+	__mon_init
 	POT_ZFS_ROOT=zpot
 	POT_FS_ROOT=/opt
-	QERR_CALLS=0
+}
+
+tearDown()
+{
+	__mon_tearDown
 }
 
 . shunit/shunit2

--- a/tests/common5.sh
+++ b/tests/common5.sh
@@ -133,9 +133,9 @@ test_fetch_freebsd_001()
 	# not downloaded
 	_fetch_freebsd 2.1
 	assertEquals "return code" "1" "$?"
-	assertEquals "fetch calls" "2" "$FETCH_CALLS"
-	assertEquals "fetch arg4" "/tmp/2.1-RELEASE_base.txz" "$FETCH_CALL1_ARG4"
-	assertEquals "error calls" "0" "$ERROR_CALLS"
+	assertEqualsMon "fetch calls" "2" FETCH_CALLS
+	assertEqualsMon "fetch arg4" "/tmp/2.1-RELEASE_base.txz" FETCH_CALL1_ARG4
+	assertEqualsMon "error calls" "0" ERROR_CALLS
 }
 
 test_fetch_freebsd_002()
@@ -143,8 +143,8 @@ test_fetch_freebsd_002()
 	# No Manifest file
 	_fetch_freebsd 8.1
 	assertEquals "return code" "1" "$?"
-	assertEquals "fetch calls" "0" "$FETCH_CALLS"
-	assertEquals "error calls" "2" "$ERROR_CALLS"
+	assertEqualsMon "fetch calls" "0" FETCH_CALLS
+	assertEqualsMon "error calls" "2" ERROR_CALLS
 }
 
 test_fetch_freebsd_003()
@@ -152,8 +152,8 @@ test_fetch_freebsd_003()
 	# Wrong sha
 	_fetch_freebsd 12.0
 	assertEquals "return code" "1" "$?"
-	assertEquals "fetch calls" "0" "$FETCH_CALLS"
-	assertEquals "error calls" "2" "$ERROR_CALLS"
+	assertEqualsMon "fetch calls" "0" FETCH_CALLS
+	assertEqualsMon "error calls" "2" ERROR_CALLS
 }
 
 test_fetch_freebsd_004()
@@ -161,8 +161,8 @@ test_fetch_freebsd_004()
 	# Everything fine
 	_fetch_freebsd 11.1
 	assertEquals "return code" "0" "$?"
-	assertEquals "fetch calls" "0" "$FETCH_CALLS"
-	assertEquals "error calls" "0" "$ERROR_CALLS"
+	assertEqualsMon "fetch calls" "0" FETCH_CALLS
+	assertEqualsMon "error calls" "0" ERROR_CALLS
 }
 
 test_fetch_freebsd_005()
@@ -170,8 +170,8 @@ test_fetch_freebsd_005()
 	# Everything fine
 	_fetch_freebsd 12.0-RC3
 	assertEquals "return code" "0" "$?"
-	assertEquals "fetch calls" "0" "$FETCH_CALLS"
-	assertEquals "error calls" "0" "$ERROR_CALLS"
+	assertEqualsMon "fetch calls" "0" FETCH_CALLS
+	assertEqualsMon "error calls" "0" ERROR_CALLS
 }
 
 test_fetch_freebsd_006()
@@ -180,12 +180,12 @@ test_fetch_freebsd_006()
 	__didfetch="0"
 	_fetch_freebsd 12.0-RC3
 	assertEquals "return code" "0" "$?"
-	assertEquals "fetch calls" "1" "$FETCH_CALLS"
-	assertEquals "fetch arg1" "-m" "$FETCH_CALL1_ARG1"
-	assertEquals "fetch arg2" "https://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/12.0-RC3/base.txz" "$FETCH_CALL1_ARG2"
-	assertEquals "fetch arg3" "-o" "$FETCH_CALL1_ARG3"
-	assertEquals "fetch arg4" "/tmp/12.0-RC3_base.txz" "$FETCH_CALL1_ARG4"
-	assertEquals "error calls" "0" "$ERROR_CALLS"
+	assertEqualsMon "fetch calls" "1" FETCH_CALLS
+	assertEqualsMon "fetch arg1" "-m" FETCH_CALL1_ARG1
+	assertEqualsMon "fetch arg2" "https://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/12.0-RC3/base.txz" FETCH_CALL1_ARG2
+	assertEqualsMon "fetch arg3" "-o" FETCH_CALL1_ARG3
+	assertEqualsMon "fetch arg4" "/tmp/12.0-RC3_base.txz" FETCH_CALL1_ARG4
+	assertEqualsMon "error calls" "0" ERROR_CALLS
 }
 
 test_fetch_freebsd_007()
@@ -196,9 +196,9 @@ test_fetch_freebsd_007()
 	__didfetch="0"
 	_fetch_freebsd 12.0-RC3
 	assertEquals "return code" "0" "$?"
-	assertEquals "fetch calls" "1" "$FETCH_CALLS"
-	assertEquals "fetch arg2" "https://ftp.freebsd.org/pub/FreeBSD/releases/arm64/aarch64/12.0-RC3/base.txz" "$FETCH_CALL1_ARG2"
-	assertEquals "error calls" "0" "$ERROR_CALLS"
+	assertEqualsMon "fetch calls" "1" FETCH_CALLS
+	assertEqualsMon "fetch arg2" "https://ftp.freebsd.org/pub/FreeBSD/releases/arm64/aarch64/12.0-RC3/base.txz" FETCH_CALL1_ARG2
+	assertEqualsMon "error calls" "0" ERROR_CALLS
 }
 
 setUp()
@@ -208,8 +208,6 @@ setUp()
 	__didfetch="1"
 	common_setUp
 	POT_CACHE="/tmp"
-	FETCH_CALLS=0
-	RM_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/common7.sh
+++ b/tests/common7.sh
@@ -114,8 +114,14 @@ test_get_usable_hostname_004()
 
 setUp()
 {
+	__mon_init
 	__machine="amd64"
 	__arch="amd64"
+}
+
+tearDown()
+{
+	__mon_tearDown
 }
 
 . shunit/shunit2

--- a/tests/conf-stub.sh
+++ b/tests/conf-stub.sh
@@ -7,7 +7,7 @@ conf_setUp()
 
 	/bin/mkdir -p /tmp/jails/test-pot/conf
 	{
-		echo "zpot/bases/11.1 /tmp/jails/test-pot/m ro" 
+		echo "zpot/bases/11.1 /tmp/jails/test-pot/m ro"
 		echo "zpot/jails/test-pot/usr.local /tmp/jails/test-pot/m/usr/local zfs-remount"
 		echo "zpot/jails/test-pot/custom /tmp/jails/test-pot/m/opt/custom zfs-remount"
 	} > /tmp/jails/test-pot/conf/fscomp.conf
@@ -54,7 +54,7 @@ conf_setUp()
 		echo "host.hostname=\"test-pot-single-run.test\""
 		echo "pot.potbase="
 	} > /tmp/jails/test-pot-single-run/conf/pot.conf
-	
+
 	/bin/mkdir -p /tmp/jails/test-pot-vnet-ip4/conf
 	touch /tmp/jails/test-pot-vnet-ip4/conf/fscomp.conf
 	{
@@ -72,7 +72,6 @@ conf_setUp()
 		echo "vnet=true"
 		echo "pot.export.ports=80 443"
 	} > /tmp/jails/test-pot-vnet-ip4/conf/pot.conf
-	
 }
 
 conf_tearDown()

--- a/tests/config1.sh
+++ b/tests/config1.sh
@@ -24,61 +24,59 @@ test_pot_config_001()
 {
 	pot-config
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "config_echo calls" "0" "$CONFECHO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "config_echo calls" "0" CONFECHO_CALLS
 
 	setUp
 	pot-config -k bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "config_echo calls" "0" "$CONFECHO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "config_echo calls" "0" CONFECHO_CALLS
 
 	setUp
 	pot-config -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "config_echo calls" "0" "$CONFECHO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "config_echo calls" "0" CONFECHO_CALLS
 }
 
 test_pot_config_002()
 {
 	pot-config -q
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "config_echo calls" "0" "$CONFECHO_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "config_echo calls" "0" CONFECHO_CALLS
 }
 
 test_pot_config_010()
 {
 	pot-config -g noname
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "config_echo calls" "0" "$CONFECHO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "config_echo calls" "0" CONFECHO_CALLS
 }
 
 test_pot_config_020()
 {
 	pot-config -g gateway
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "config_echo calls" "1" "$CONFECHO_CALLS"
-	assertEquals "config_echo arg" "NO" "$CONFECHO_CALL1_ARG1"
-	assertEquals "config_echo arg" "gateway" "$CONFECHO_CALL1_ARG2"
-	assertEquals "config_echo arg" "10.1.2.3" "$CONFECHO_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "config_echo calls" "1" CONFECHO_CALLS
+	assertEqualsMon "config_echo arg" "NO" CONFECHO_CALL1_ARG1
+	assertEqualsMon "config_echo arg" "gateway" CONFECHO_CALL1_ARG2
+	assertEqualsMon "config_echo arg" "10.1.2.3" CONFECHO_CALL1_ARG3
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	CONFECHO_CALLS=0
-	POT_GATEWAY=10.1.2.3
+	POT_GATEWAY="10.1.2.3"
 }
 
 . shunit/shunit2

--- a/tests/copy-in1.sh
+++ b/tests/copy-in1.sh
@@ -83,195 +83,195 @@ test_pot_copy_in_001()
 {
 	pot-copy-in
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-copy-in -vb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-copy-in -b bb
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-copy-in -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 }
 
 test_pot_copy_in_002()
 {
 	pot-copy-in -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-in -s test-file
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-in -d test-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-in -p test-pot -s test-file
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-in -d test-mnt -s test-file
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-in -d test-mnt -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 }
 
 test_pot_copy_in_003()
 {
 	pot-copy-in -p test-no-pot -s test-no-file -d /test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
 }
 
 test_pot_copy_in_004()
 {
 	pot-copy-in -p test-no-pot -s test-file -d /test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_copy_in_005()
 {
 	pot-copy-in -p test-pot -s test-no-file -d /test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_source_validation calls" "1" SRCVALID_CALLS
 }
 
 test_pot_copy_in_006()
 {
 	pot-copy-in -p test-pot-run -s test-file -d /test-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
-	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
-	assertEquals "_jail calls" "0" "$JAIL_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_source_validation calls" "1" SRCVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "0" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "0" JEXEC_CALLS
+	assertEqualsMon "_jail calls" "0" JAIL_CALLS
 }
 
 test_pot_copy_in_020()
 {
 	pot-copy-in -p test-pot -s test-file -d /test-mnt
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
-	assertEquals "_pot_mount calls" "1" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
-	assertEquals "_jail calls" "1" "$JAIL_CALLS"
-	assertEquals "_jail args" "-c" "$JAIL_CALL1_ARG1"
-	assertEquals "_jail args" "/tmp/copy-in.asdf/test-file" "$JAIL_CALL1_ARG5"
-	assertEquals "_jail args" "/test-mnt" "$JAIL_CALL1_ARG6"
-	assertEquals "_pot_umount calls" "1" "$PUMOUNT_CALLS"
-	assertEquals "_rmdir calls" "0" "$RMDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_source_validation calls" "1" SRCVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "1" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "0" JEXEC_CALLS
+	assertEqualsMon "_jail calls" "1" JAIL_CALLS
+	assertEqualsMon "_jail args" "-c" JAIL_CALL1_ARG1
+	assertEqualsMon "_jail args" "/tmp/copy-in.asdf/test-file" JAIL_CALL1_ARG5
+	assertEqualsMon "_jail args" "/test-mnt" JAIL_CALL1_ARG6
+	assertEqualsMon "_pot_umount calls" "1" PUMOUNT_CALLS
+	assertEqualsMon "_rmdir calls" "0" RMDIR_CALLS
 }
 
 test_pot_copy_in_021()
 {
 	pot-copy-in -p test-pot-run -s test-file -d /test-mnt -F
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
-	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "1" "$JEXEC_CALLS"
-	assertEquals "_jexec args" "test-pot-run" "$JEXEC_CALL1_ARG1"
-	assertEquals "_jexec args" "-a" "$JEXEC_CALL1_ARG3"
-	assertEquals "_jexec args" "/tmp/copy-in.asdf/test-file" "$JEXEC_CALL1_ARG4"
-	assertEquals "_jexec args" "/test-mnt" "$JEXEC_CALL1_ARG5"
-	assertEquals "_jail calls" "0" "$JAIL_CALLS"
-	assertEquals "_pot_umount calls" "0" "$PUMOUNT_CALLS"
-	assertEquals "_rmdir calls" "1" "$RMDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_source_validation calls" "1" SRCVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "0" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "1" JEXEC_CALLS
+	assertEqualsMon "_jexec args" "test-pot-run" JEXEC_CALL1_ARG1
+	assertEqualsMon "_jexec args" "-a" JEXEC_CALL1_ARG3
+	assertEqualsMon "_jexec args" "/tmp/copy-in.asdf/test-file" JEXEC_CALL1_ARG4
+	assertEqualsMon "_jexec args" "/test-mnt" JEXEC_CALL1_ARG5
+	assertEqualsMon "_jail calls" "0" JAIL_CALLS
+	assertEqualsMon "_pot_umount calls" "0" PUMOUNT_CALLS
+	assertEqualsMon "_rmdir calls" "1" RMDIR_CALLS
 }
 
 test_pot_copy_in_022()
 {
 	pot-copy-in -p test-pot-run -s test-file -d /test-mnt -vF
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
-	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "1" "$JEXEC_CALLS"
-	assertEquals "_jexec args" "test-pot-run" "$JEXEC_CALL1_ARG1"
-	assertEquals "_jexec args" "-va" "$JEXEC_CALL1_ARG3"
-	assertEquals "_jexec args" "/tmp/copy-in.asdf/test-file" "$JEXEC_CALL1_ARG4"
-	assertEquals "_jexec args" "/test-mnt" "$JEXEC_CALL1_ARG5"
-	assertEquals "_jail calls" "0" "$JAIL_CALLS"
-	assertEquals "_pot_umount calls" "0" "$PUMOUNT_CALLS"
-	assertEquals "_rmdir calls" "1" "$RMDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_source_validation calls" "1" SRCVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "0" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "1" JEXEC_CALLS
+	assertEqualsMon "_jexec args" "test-pot-run" JEXEC_CALL1_ARG1
+	assertEqualsMon "_jexec args" "-va" JEXEC_CALL1_ARG3
+	assertEqualsMon "_jexec args" "/tmp/copy-in.asdf/test-file" JEXEC_CALL1_ARG4
+	assertEqualsMon "_jexec args" "/test-mnt" JEXEC_CALL1_ARG5
+	assertEqualsMon "_jail calls" "0" JAIL_CALLS
+	assertEqualsMon "_pot_umount calls" "0" PUMOUNT_CALLS
+	assertEqualsMon "_rmdir calls" "1" RMDIR_CALLS
 }
 
 test_pot_copy_in_023()
 {
 	pot-copy-in -p test-pot -s test-dir -d /test-mnt -v
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
-	assertEquals "_pot_mount calls" "1" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
-	assertEquals "_jail calls" "1" "$JAIL_CALLS"
-	assertEquals "_jail args" "-c" "$JAIL_CALL1_ARG1"
-	assertEquals "_jail args" "/tmp/copy-in.asdf" "$JAIL_CALL1_ARG5"
-	assertEquals "_jail args" "/test-mnt" "$JAIL_CALL1_ARG6"
-	assertEquals "_pot_umount calls" "1" "$PUMOUNT_CALLS"
-	assertEquals "_rmdir calls" "0" "$RMDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_source_validation calls" "1" SRCVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "1" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "0" JEXEC_CALLS
+	assertEqualsMon "_jail calls" "1" JAIL_CALLS
+	assertEqualsMon "_jail args" "-c" JAIL_CALL1_ARG1
+	assertEqualsMon "_jail args" "/tmp/copy-in.asdf" JAIL_CALL1_ARG5
+	assertEqualsMon "_jail args" "/test-mnt" JAIL_CALL1_ARG6
+	assertEqualsMon "_pot_umount calls" "1" PUMOUNT_CALLS
+	assertEqualsMon "_rmdir calls" "0" RMDIR_CALLS
 }
 
 setUp()
@@ -279,16 +279,6 @@ setUp()
 	common_setUp
 	ERROR_DEBUG="NO"
 	DEBUG_DEBUG="NO"
-	HELP_CALLS=0
-	SRCVALID_CALLS=0
-	JAIL_CALLS=0
-	JEXEC_CALLS=0
-	MKTEMP_CALLS=0
-	UMOUNT_CALLS=0
-	PMOUNT_CALLS=0
-	PUMOUNT_CALLS=0
-	RMDIR_CALLS=0
-
 	POT_FS_ROOT=/tmp
 	POT_ZFS_ROOT=zpot
 }

--- a/tests/copy-out1.sh
+++ b/tests/copy-out1.sh
@@ -81,195 +81,195 @@ test_pot_copy_out_001()
 {
 	pot-copy-out
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-copy-out -vb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-copy-out -b bb
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-copy-out -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 }
 
 test_pot_copy_out_002()
 {
 	pot-copy-out -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-out -s test-file
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-out -d test-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-out -p test-pot -s test-file
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-out -d test-mnt -s test-file
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 
 	setUp
 	pot-copy-out -d test-mnt -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
 }
 
 test_pot_copy_out_003()
 {
 	pot-copy-out -p test-no-pot -s /test-no-file -d test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
 }
 
 test_pot_copy_out_004()
 {
 	pot-copy-out -p test-no-pot -s /test-file -d test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_copy_out_005()
 {
 	pot-copy-out -p test-pot -s /test-no-file -d test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_destination_validation calls" "1" "$DSTVALID_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_destination_validation calls" "1" DSTVALID_CALLS
 }
 
 test_pot_copy_out_006()
 {
 	pot-copy-out -p test-pot-run -s /test-file -d test-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_destination_validation calls" "1" "$DSTVALID_CALLS"
-	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
-	assertEquals "_jail calls" "0" "$JAIL_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_destination_validation calls" "1" DSTVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "0" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "0" JEXEC_CALLS
+	assertEqualsMon "_jail calls" "0" JAIL_CALLS
 }
 
 test_pot_copy_out_020()
 {
 	pot-copy-out -p test-pot -s /test-file -d test-mnt
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_destination_validation calls" "1" "$DSTVALID_CALLS"
-	assertEquals "_pot_mount calls" "1" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
-	assertEquals "_jail calls" "1" "$JAIL_CALLS"
-	assertEquals "_jail args" "-c" "$JAIL_CALL1_ARG1"
-	assertEquals "_jail args" "/test-file" "$JAIL_CALL1_ARG5"
-	assertEquals "_jail args" "/tmp/copy-out.asdf" "$JAIL_CALL1_ARG6"
-	assertEquals "_pot_umount calls" "1" "$PUMOUNT_CALLS"
-	assertEquals "_rmdir calls" "0" "$RMDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_destination_validation calls" "1" DSTVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "1" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "0" JEXEC_CALLS
+	assertEqualsMon "_jail calls" "1" JAIL_CALLS
+	assertEqualsMon "_jail args" "-c" JAIL_CALL1_ARG1
+	assertEqualsMon "_jail args" "/test-file" JAIL_CALL1_ARG5
+	assertEqualsMon "_jail args" "/tmp/copy-out.asdf" JAIL_CALL1_ARG6
+	assertEqualsMon "_pot_umount calls" "1" PUMOUNT_CALLS
+	assertEqualsMon "_rmdir calls" "0" RMDIR_CALLS
 }
 
 test_pot_copy_out_021()
 {
 	pot-copy-out -p test-pot-run -s /test-file -d test-mnt -F
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_destination_validation calls" "1" "$DSTVALID_CALLS"
-	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "1" "$JEXEC_CALLS"
-	assertEquals "_jexec args" "test-pot-run" "$JEXEC_CALL1_ARG1"
-	assertEquals "_jexec args" "-a" "$JEXEC_CALL1_ARG3"
-	assertEquals "_jexec args" "/test-file" "$JEXEC_CALL1_ARG4"
-	assertEquals "_jexec args" "/tmp/copy-out.asdf" "$JEXEC_CALL1_ARG5"
-	assertEquals "_jail calls" "0" "$JAIL_CALLS"
-	assertEquals "_pot_umount calls" "0" "$PUMOUNT_CALLS"
-	assertEquals "_rmdir calls" "1" "$RMDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_destination_validation calls" "1" DSTVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "0" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "1" JEXEC_CALLS
+	assertEqualsMon "_jexec args" "test-pot-run" JEXEC_CALL1_ARG1
+	assertEqualsMon "_jexec args" "-a" JEXEC_CALL1_ARG3
+	assertEqualsMon "_jexec args" "/test-file" JEXEC_CALL1_ARG4
+	assertEqualsMon "_jexec args" "/tmp/copy-out.asdf" JEXEC_CALL1_ARG5
+	assertEqualsMon "_jail calls" "0" JAIL_CALLS
+	assertEqualsMon "_pot_umount calls" "0" PUMOUNT_CALLS
+	assertEqualsMon "_rmdir calls" "1" RMDIR_CALLS
 }
 
 test_pot_copy_out_022()
 {
 	pot-copy-out -p test-pot-run -s /test-file -d test-mnt -vF
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_destination_validation calls" "1" "$DSTVALID_CALLS"
-	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "1" "$JEXEC_CALLS"
-	assertEquals "_jexec args" "test-pot-run" "$JEXEC_CALL1_ARG1"
-	assertEquals "_jexec args" "-va" "$JEXEC_CALL1_ARG3"
-	assertEquals "_jexec args" "/test-file" "$JEXEC_CALL1_ARG4"
-	assertEquals "_jexec args" "/tmp/copy-out.asdf" "$JEXEC_CALL1_ARG5"
-	assertEquals "_jail calls" "0" "$JAIL_CALLS"
-	assertEquals "_pot_umount calls" "0" "$PUMOUNT_CALLS"
-	assertEquals "_rmdir calls" "1" "$RMDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_destination_validation calls" "1" DSTVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "0" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "1" JEXEC_CALLS
+	assertEqualsMon "_jexec args" "test-pot-run" JEXEC_CALL1_ARG1
+	assertEqualsMon "_jexec args" "-va" JEXEC_CALL1_ARG3
+	assertEqualsMon "_jexec args" "/test-file" JEXEC_CALL1_ARG4
+	assertEqualsMon "_jexec args" "/tmp/copy-out.asdf" JEXEC_CALL1_ARG5
+	assertEqualsMon "_jail calls" "0" JAIL_CALLS
+	assertEqualsMon "_pot_umount calls" "0" PUMOUNT_CALLS
+	assertEqualsMon "_rmdir calls" "1" RMDIR_CALLS
 }
 
 test_pot_copy_out_023()
 {
 	pot-copy-out -p test-pot -s /test-dir -d test-mnt -v
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_destination_validation calls" "1" "$DSTVALID_CALLS"
-	assertEquals "_pot_mount calls" "1" "$PMOUNT_CALLS"
-	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
-	assertEquals "_jail calls" "1" "$JAIL_CALLS"
-	assertEquals "_jail args" "-c" "$JAIL_CALL1_ARG1"
-	assertEquals "_jail args" "/test-dir" "$JAIL_CALL1_ARG5"
-	assertEquals "_jail args" "/tmp/copy-out.asdf" "$JAIL_CALL1_ARG6"
-	assertEquals "_pot_umount calls" "1" "$PUMOUNT_CALLS"
-	assertEquals "_rmdir calls" "0" "$RMDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_destination_validation calls" "1" DSTVALID_CALLS
+	assertEqualsMon "_pot_mount calls" "1" PMOUNT_CALLS
+	assertEqualsMon "_jexec calls" "0" JEXEC_CALLS
+	assertEqualsMon "_jail calls" "1" JAIL_CALLS
+	assertEqualsMon "_jail args" "-c" JAIL_CALL1_ARG1
+	assertEqualsMon "_jail args" "/test-dir" JAIL_CALL1_ARG5
+	assertEqualsMon "_jail args" "/tmp/copy-out.asdf" JAIL_CALL1_ARG6
+	assertEqualsMon "_pot_umount calls" "1" PUMOUNT_CALLS
+	assertEqualsMon "_rmdir calls" "0" RMDIR_CALLS
 }
 
 setUp()
@@ -277,16 +277,6 @@ setUp()
 	common_setUp
 	ERROR_DEBUG="NO"
 	DEBUG_DEBUG="NO"
-	HELP_CALLS=0
-	DSTVALID_CALLS=0
-	JAIL_CALLS=0
-	JEXEC_CALLS=0
-	MKTEMP_CALLS=0
-	RMDIR_CALLS=0
-	UMOUNT_CALLS=0
-	PMOUNT_CALLS=0
-	PUMOUNT_CALLS=0
-
 	POT_FS_ROOT=/tmp
 	POT_ZFS_ROOT=zpot
 }

--- a/tests/create-base1.sh
+++ b/tests/create-base1.sh
@@ -50,72 +50,72 @@ test_base_create_base_001()
 {
 	pot-create-base
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 
 	setUp
 	pot-create-base -vL
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 
 	setUp
 	pot-create-base -L bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 
 	setUp
 	pot-create-base -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 }
 
 test_base_create_base_002()
 {
 	pot-create-base -r 1234
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 }
 
 test_base_create_base_003()
 {
 	pot-create-base -b 104x64
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 }
 
 test_base_create_base_004()
@@ -123,13 +123,13 @@ test_base_create_base_004()
 	# base name is invalid
 	pot-create-base -r 11.1 -b 10.4
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 }
 
 test_base_create_base_010()
@@ -137,13 +137,13 @@ test_base_create_base_010()
 	# simulate fetch issue
 	pot-create-base -r 10.1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "1" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "1" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 }
 
 test_base_create_base_011()
@@ -151,67 +151,62 @@ test_base_create_base_011()
 	# simulate zfs issue
 	pot-create-base -r 11.0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "1" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "1" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "1" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "1" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 }
 
 test_base_create_base_012()
 {
 	pot-create-base -r 11.1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 }
 
 test_base_create_base_013()
 {
 	pot-create-base -r 11.1 -b test-base
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "0" "$FETCHBSD_CALLS"
-	assertEquals "_cb_zfs calls" "0" "$CBZFS_CALLS"
-	assertEquals "_cb_tar_dir calls" "0" "$CBTAR_CALLS"
-	assertEquals "_cb_base_pot calls" "0" "$CBPOT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "0" FETCHBSD_CALLS
+	assertEqualsMon "_cb_zfs calls" "0" CBZFS_CALLS
+	assertEqualsMon "_cb_tar_dir calls" "0" CBTAR_CALLS
+	assertEqualsMon "_cb_base_pot calls" "0" CBPOT_CALLS
 }
 
 test_base_create_base_020()
 {
 	pot-create-base -r 11.1 -b new-test-base
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_fetch calls" "1" "$FETCHBSD_CALLS"
-	assertEquals "_fetch arg" "11.1" "$FETCHBSD_CALL1_ARG1"
-	assertEquals "_cb_zfs calls" "1" "$CBZFS_CALLS"
-	assertEquals "_cb_zfs arg" "new-test-base" "$CBZFS_CALL1_ARG1"
-	assertEquals "_cb_tar_dir calls" "1" "$CBTAR_CALLS"
-	assertEquals "_cb_tar_dir arg" "11.1" "$CBTAR_CALL1_ARG1"
-	assertEquals "_cb_tar_dir arg" "new-test-base" "$CBTAR_CALL1_ARG2"
-	assertEquals "_cb_base_pot calls" "1" "$CBPOT_CALLS"
-	assertEquals "_cb_base_pot arg" "new-test-base" "$CBPOT_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_fetch calls" "1" FETCHBSD_CALLS
+	assertEqualsMon "_fetch arg" "11.1" FETCHBSD_CALL1_ARG1
+	assertEqualsMon "_cb_zfs calls" "1" CBZFS_CALLS
+	assertEqualsMon "_cb_zfs arg" "new-test-base" CBZFS_CALL1_ARG1
+	assertEqualsMon "_cb_tar_dir calls" "1" CBTAR_CALLS
+	assertEqualsMon "_cb_tar_dir arg" "11.1" CBTAR_CALL1_ARG1
+	assertEqualsMon "_cb_tar_dir arg" "new-test-base" CBTAR_CALL1_ARG2
+	assertEqualsMon "_cb_base_pot calls" "1" CBPOT_CALLS
+	assertEqualsMon "_cb_base_pot arg" "new-test-base" CBPOT_CALL1_ARG1
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	FETCHBSD_CALLS=0
-	CBZFS_CALLS=0
-	CBTAR_CALLS=0
-	CBPOT_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/create-fscomp1.sh
+++ b/tests/create-fscomp1.sh
@@ -37,68 +37,63 @@ test_pot_create_fscomp_001()
 {
 	pot-create-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-create-fscomp -vb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-create-fscomp -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-create-fscomp -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_fscomp_002()
 {
 	pot-create-fscomp -f test-fscomp
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "1" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "zfs calls" "0" "$ZFS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "1" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "zfs calls" "0" ZFS_CALLS
 }
 
 test_pot_create_fscomp_020()
 {
 	pot-create-fscomp -f new-fscomp
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "1" "$ZDSET_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "zfs calls" "1" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "/fscomp/new-fscomp" "$ZFS_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "1" ZDSET_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "zfs calls" "1" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "/fscomp/new-fscomp" ZFS_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	ZDSET_CALLS=0
-	HELP_CALLS=0
-	ZFS_CALLS=0
-	ZFS_CALL1_ARG1=
-	ZFS_CALL1_ARG2=
 }
 
 . shunit/shunit2

--- a/tests/create-private-bridge1.sh
+++ b/tests/create-private-bridge1.sh
@@ -41,47 +41,47 @@ test_create_private_bridge_001()
 {
 	pot-create-private-bridge
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-create-private-bridge -vL
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-create-private-bridge -L bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 
 	setUp
 	pot-create-private-bridge -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_create_private_bridge_002()
 {
 	pot-create-private-bridge -B test-bridge
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_create_bridge calls" "0" "$CB_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_create_bridge calls" "0" CB_CALLS
 }
 
 test_create_private_bridge_003()
 {
 	pot-create-private-bridge -S 5
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_create_bridge calls" "0" "$CB_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_create_bridge calls" "0" CB_CALLS
 }
 
 test_create_private_bridge_010()
@@ -89,29 +89,26 @@ test_create_private_bridge_010()
 	# bridge already exists
 	pot-create-private-bridge -B test-bridge -S 5
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_create_bridge calls" "0" "$CB_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_create_bridge calls" "0" CB_CALLS
 }
 
 test_create_private_bridge_020()
 {
 	pot-create-private-bridge -B new-test-bridge -S 5
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_create_bridge calls" "1" "$CB_CALLS"
-	assertEquals "_create_bridge arg1" "new-test-bridge" "$CB_CALL1_ARG1"
-	assertEquals "_create_bridge arg2" "5" "$CB_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_create_bridge calls" "1" CB_CALLS
+	assertEqualsMon "_create_bridge arg1" "new-test-bridge" CB_CALL1_ARG1
+	assertEqualsMon "_create_bridge arg2" "5" CB_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	FETCHBSD_CALLS=0
-	CB_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/create1.sh
+++ b/tests/create1.sh
@@ -87,621 +87,621 @@ test_pot_create_001()
 {
 	pot-create
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-create -vL
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-create -L bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-create -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-create -S
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_002()
 {
 	pot-create -p test-pot -b 11.1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_003()
 {
 	pot-create -p new-pot -P test-pot -l 0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-create -p new-pot -b 11.1 -P test-pot -l 0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_004()
 {
 	pot-create -p new-pot -P test-pot2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-create -p new-pot -P test-pot2 -l 1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-create -p new-pot -b 11.1 -l 2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_005()
 {
 	pot-create -p new-pot -b 12.1 -N alias -I
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 
 	setUp
 	pot-create -p new-pot -b 12.1 -N alias -I removed-option
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_006()
 {
 	pot-create -p new-pot -b 12.1 -N alias -S no-valid-stack
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_007()
 {
 	pot-create -p new.pot -b 12.1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_020()
 {
 	pot-create -p new-pot -b 11.1
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "multi" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "multi" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_021()
 {
 	pot-create -p new-pot -P test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "multi" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "test-pot" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "test-pot" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "multi" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "test-pot" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "test-pot" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_022()
 {
 	pot-create -p new-pot -P test-pot -S
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_023()
 {
 	pot-create -p new-pot -P test-pot -b 10.4
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_024()
 {
 	pot-create -p new-pot -P test-pot-0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_025()
 {
 	pot-create -p new-pot -b 11.1
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "multi" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "multi" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_026()
 {
 	pot-create -p new-pot -b 11.1 -f flap
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "multi" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "1" "$EXEC_FLV_CALLS"
-	assertEquals "_exec_flv arg2" "flap" "$EXEC_FLV_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "multi" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "1" EXEC_FLV_CALLS
+	assertEqualsMon "_exec_flv arg2" "flap" EXEC_FLV_CALL1_ARG2
 }
 
 test_pot_create_027()
 {
 	pot-create -p new-pot -b 11.1 -S ipv6 -f flap
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "multi" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "ipv6" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "1" "$EXEC_FLV_CALLS"
-	assertEquals "_exec_flv arg2" "flap" "$EXEC_FLV_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "multi" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "ipv6" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "1" EXEC_FLV_CALLS
+	assertEqualsMon "_exec_flv arg2" "flap" EXEC_FLV_CALL1_ARG2
 }
 
 test_pot_create_028()
 {
 	pot-create -p new-pot -b 11.1 -f flap -f flap2
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "multi" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "2" "$EXEC_FLV_CALLS"
-	assertEquals "_exec_flv arg2" "flap" "$EXEC_FLV_CALL1_ARG2"
-	assertEquals "_exec_flv arg2" "flap2" "$EXEC_FLV_CALL2_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "multi" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "2" EXEC_FLV_CALLS
+	assertEqualsMon "_exec_flv arg2" "flap" EXEC_FLV_CALL1_ARG2
+	assertEqualsMon "_exec_flv arg2" "flap2" EXEC_FLV_CALL2_ARG2
 }
 
 test_pot_create_030()
 {
 	pot-create -p new-pot -b 11.1 -f no-flav
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 test_pot_create_040()
 {
 	pot-create -p new-pot -P test-pot -l 2
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "2" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "test-pot" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "2" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "test-pot" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "2" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "test-pot" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "2" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "test-pot" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_041()
 {
 	pot-create -p new-pot -b 11.1 -P test-pot -l 2
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "2" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "test-pot" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "2" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "test-pot" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "2" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "test-pot" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "2" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "test-pot" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_042()
 {
 	pot-create -p new-pot -P test-pot -b 10.4 -l 2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_060()
 {
 	pot-create -p new-pot -b 11.1 -N inherit
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_is_vnet_available calls" "0" "$ISVNETAVAIL_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
-	assertEquals "_potnet calls" "0" "$POTNET_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_is_vnet_available calls" "0" ISVNETAVAIL_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
+	assertEqualsMon "_potnet calls" "0" POTNET_CALLS
 }
 
 test_pot_create_061()
 {
 	pot-create -p new-pot -b 11.1 -N inherit -s
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_062()
 {
 	pot-create -p new-pot -b 11.1 -N public-bridge -i 10.1.2.3
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.2.3" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.2.3" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_063()
 {
 	pot-create -p new-pot -b 11.1 -N alias -i 10.1.2.3
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_is_vnet_available calls" "0" "$ISVNETAVAIL_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "alias" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.2.3" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_is_vnet_available calls" "0" ISVNETAVAIL_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "alias" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.2.3" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_064()
 {
 	pot-create -p new-pot -b 11.1 -N public-bridge -i auto
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.192.123.123" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.192.123.123" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_065()
@@ -709,11 +709,11 @@ test_pot_create_065()
 	# -s is ignored in this case
 	pot-create -p new-pot -b 11.1 -N alias -i auto
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 	# an empty error message is printed because _error is re-implemented in the stub
 }
 
@@ -721,130 +721,130 @@ test_pot_create_080()
 {
 	pot-create -p new-pot -b 11.1 -d asdf
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "0" "$CJZFS_CALLS"
-	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "0" CJZFS_CALLS
+	assertEqualsMon "_cj_conf calls" "0" CJCONF_CALLS
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_081()
 {
 	pot-create -p new-pot -b 11.1 -d pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_is_vnet_available calls" "1" "$ISVNETAVAIL_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "pot" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_is_vnet_available calls" "1" ISVNETAVAIL_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "pot" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_082()
 {
 	pot-create -p new-pot -b 11.1 -N public-bridge -i 10.1.2.3 -d pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_is_vnet_available calls" "1" "$ISVNETAVAIL_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.2.3" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "pot" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_is_vnet_available calls" "2" ISVNETAVAIL_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.2.3" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "pot" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_083()
 {
 	pot-create -p new-pot -b 11.1 -N alias -i 10.1.2.3 -d pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_is_vnet_available calls" "1" "$ISVNETAVAIL_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "alias" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.2.3" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "pot" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_is_vnet_available calls" "1" ISVNETAVAIL_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "alias" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.2.3" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "pot" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_084()
 {
 	pot-create -p new-pot -b 11.1 -N public-bridge -i 10.1.2.3 -d off
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_is_vnet_available calls" "0" "$ISVNETAVAIL_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg3" "1" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.2.3" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "1" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "off" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "multi" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_is_vnet_available calls" "1" ISVNETAVAIL_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg3" "1" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.2.3" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "1" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "off" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "multi" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "0" CJICONF_CALLS
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 
@@ -852,200 +852,183 @@ test_pot_create_100()
 {
 	pot-create -p new-pot -t single
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_101()
 {
 	pot-create -p new-pot -t single -b no-base
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_102()
 {
 	pot-create -p new-pot -t single -P no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_103()
 {
 	pot-create -p new-pot -t single -P test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_104()
 {
 	pot-create -p test-pot -t single -b 11.1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_105()
 {
 	pot-create -p new-pot -t single -P test-pot-0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_106()
 {
 	pot-create -p new-pot -t single -P test-pot-single -b 10.3
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_107()
 {
 	pot-create -p new-pot -t single -b 11.1 -l 1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
 }
 
 test_pot_create_120()
 {
 	pot-create -p new-pot -b 11.1 -t single
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_is_vnet_available calls" "0" "$ISVNETAVAIL_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "single" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "0" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "0" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "single" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "1" "$CJSINGLE_CALLS"
-	assertEquals "_cj_single_install arg1" "new-pot" "$CJSINGLE_CALL1_ARG1"
-	assertEquals "_cj_single_install arg2" "11.1" "$CJSINGLE_CALL1_ARG2"
-	assertEquals "_cj_interal_conf calls" "1" "$CJICONF_CALLS"
-	assertEquals "_cj_interal_conf arg1" "new-pot" "$CJICONF_CALL1_ARG1"
-	assertEquals "_cj_interal_conf arg2" "single" "$CJICONF_CALL1_ARG2"
-	assertEquals "_cj_interal_conf arg3" "0" "$CJICONF_CALL1_ARG3"
-	assertEquals "_cj_interal_conf arg4" "" "$CJICONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_is_vnet_available calls" "0" ISVNETAVAIL_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "single" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "0" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "0" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "single" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "1" CJSINGLE_CALLS
+	assertEqualsMon "_cj_single_install arg1" "new-pot" CJSINGLE_CALL1_ARG1
+	assertEqualsMon "_cj_single_install arg2" "11.1" CJSINGLE_CALL1_ARG2
+	assertEqualsMon "_cj_interal_conf calls" "1" CJICONF_CALLS
+	assertEqualsMon "_cj_interal_conf arg1" "new-pot" CJICONF_CALL1_ARG1
+	assertEqualsMon "_cj_interal_conf arg2" "single" CJICONF_CALL1_ARG2
+	assertEqualsMon "_cj_interal_conf arg3" "0" CJICONF_CALL1_ARG3
+	assertEqualsMon "_cj_interal_conf arg4" "" CJICONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_121()
 {
 	pot-create -p new-pot -b 11.1 -t single -N public-bridge -i 10.1.2.3
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "single" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "0" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "public-bridge" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "10.1.2.3" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "0" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "single" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "1" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "1" "$CJICONF_CALLS"
-	assertEquals "_cj_single_install arg1" "new-pot" "$CJSINGLE_CALL1_ARG1"
-	assertEquals "_cj_single_install arg2" "11.1" "$CJSINGLE_CALL1_ARG2"
-	assertEquals "_cj_interal_conf arg1" "new-pot" "$CJICONF_CALL1_ARG1"
-	assertEquals "_cj_interal_conf arg2" "single" "$CJICONF_CALL1_ARG2"
-	assertEquals "_cj_interal_conf arg3" "0" "$CJICONF_CALL1_ARG3"
-	assertEquals "_cj_interal_conf arg4" "10.1.2.3" "$CJICONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "single" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "0" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "public-bridge" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "10.1.2.3" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "0" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "single" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "1" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "1" CJICONF_CALLS
+	assertEqualsMon "_cj_single_install arg1" "new-pot" CJSINGLE_CALL1_ARG1
+	assertEqualsMon "_cj_single_install arg2" "11.1" CJSINGLE_CALL1_ARG2
+	assertEqualsMon "_cj_interal_conf arg1" "new-pot" CJICONF_CALL1_ARG1
+	assertEqualsMon "_cj_interal_conf arg2" "single" CJICONF_CALL1_ARG2
+	assertEqualsMon "_cj_interal_conf arg3" "0" CJICONF_CALL1_ARG3
+	assertEqualsMon "_cj_interal_conf arg4" "10.1.2.3" CJICONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
 }
 
 test_pot_create_122()
 {
 	pot-create -p new-pot -P test-pot-single -t single
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_is_vnet_available calls" "0" "$ISVNETAVAIL_CALLS"
-	assertEquals "_cj_zfs calls" "1" "$CJZFS_CALLS"
-	assertEquals "_cj_zfs arg1" "new-pot" "$CJZFS_CALL1_ARG1"
-	assertEquals "_cj_zfs arg2" "single" "$CJZFS_CALL1_ARG2"
-	assertEquals "_cj_zfs arg3" "0" "$CJZFS_CALL1_ARG3"
-	assertEquals "_cj_zfs arg4" "11.1" "$CJZFS_CALL1_ARG4"
-	assertEquals "_cj_zfs arg5" "test-pot-single" "$CJZFS_CALL1_ARG5"
-	assertEquals "_cj_conf calls" "1" "$CJCONF_CALLS"
-	assertEquals "_cj_conf arg1" "new-pot" "$CJCONF_CALL1_ARG1"
-	assertEquals "_cj_conf arg2" "11.1" "$CJCONF_CALL1_ARG2"
-	assertEquals "_cj_conf arg3" "inherit" "$CJCONF_CALL1_ARG3"
-	assertEquals "_cj_conf arg4" "" "$CJCONF_CALL1_ARG4"
-	assertEquals "_cj_conf arg5" "0" "$CJCONF_CALL1_ARG5"
-	assertEquals "_cj_conf arg6" "inherit" "$CJCONF_CALL1_ARG6"
-	assertEquals "_cj_conf arg7" "single" "$CJCONF_CALL1_ARG7"
-	assertEquals "_cj_conf arg8" "" "$CJCONF_CALL1_ARG8"
-	assertEquals "_cj_conf arg9" "test-pot-single" "$CJCONF_CALL1_ARG9"
-	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
-	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
-	assertEquals "_cj_interal_conf calls" "1" "$CJICONF_CALLS"
-	assertEquals "_cj_interal_conf arg1" "new-pot" "$CJICONF_CALL1_ARG1"
-	assertEquals "_cj_interal_conf arg2" "single" "$CJICONF_CALL1_ARG2"
-	assertEquals "_cj_interal_conf arg3" "0" "$CJICONF_CALL1_ARG3"
-	assertEquals "_cj_interal_conf arg4" "" "$CJICONF_CALL1_ARG4"
-	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
-	assertEquals "_potnet calls" "0" "$POTNET_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_is_vnet_available calls" "0" ISVNETAVAIL_CALLS
+	assertEqualsMon "_cj_zfs calls" "1" CJZFS_CALLS
+	assertEqualsMon "_cj_zfs arg1" "new-pot" CJZFS_CALL1_ARG1
+	assertEqualsMon "_cj_zfs arg2" "single" CJZFS_CALL1_ARG2
+	assertEqualsMon "_cj_zfs arg3" "0" CJZFS_CALL1_ARG3
+	assertEqualsMon "_cj_zfs arg4" "11.1" CJZFS_CALL1_ARG4
+	assertEqualsMon "_cj_zfs arg5" "test-pot-single" CJZFS_CALL1_ARG5
+	assertEqualsMon "_cj_conf calls" "1" CJCONF_CALLS
+	assertEqualsMon "_cj_conf arg1" "new-pot" CJCONF_CALL1_ARG1
+	assertEqualsMon "_cj_conf arg2" "11.1" CJCONF_CALL1_ARG2
+	assertEqualsMon "_cj_conf arg3" "inherit" CJCONF_CALL1_ARG3
+	assertEqualsMon "_cj_conf arg4" "" CJCONF_CALL1_ARG4
+	assertEqualsMon "_cj_conf arg5" "0" CJCONF_CALL1_ARG5
+	assertEqualsMon "_cj_conf arg6" "inherit" CJCONF_CALL1_ARG6
+	assertEqualsMon "_cj_conf arg7" "single" CJCONF_CALL1_ARG7
+	assertEqualsMon "_cj_conf arg8" "" CJCONF_CALL1_ARG8
+	assertEqualsMon "_cj_conf arg9" "test-pot-single" CJCONF_CALL1_ARG9
+	assertEqualsMon "_cj_conf_arg10" "dual" CJCONF_CALL1_ARG10
+	assertEqualsMon "_cj_single_install calls" "0" CJSINGLE_CALLS
+	assertEqualsMon "_cj_interal_conf calls" "1" CJICONF_CALLS
+	assertEqualsMon "_cj_interal_conf arg1" "new-pot" CJICONF_CALL1_ARG1
+	assertEqualsMon "_cj_interal_conf arg2" "single" CJICONF_CALL1_ARG2
+	assertEqualsMon "_cj_interal_conf arg3" "0" CJICONF_CALL1_ARG3
+	assertEqualsMon "_cj_interal_conf arg4" "" CJICONF_CALL1_ARG4
+	assertEqualsMon "_exec_flv calls" "0" EXEC_FLV_CALLS
+	assertEqualsMon "_potnet calls" "0" POTNET_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	CJZFS_CALLS=0
-	CJZFS_CALL1_ARG5=
-	CJSINGLE_CALLS=0
-	CJSINGLE_CALL1_ARG1=
-	CJCONF_CALLS=0
-	CJCONF_CALL1_ARG1=
-	CJCONF_CALL1_ARG8=
-	CJCONF_CALL1_ARG9=
-	CJCONF_CALL1_ARG10=
-	CJICONF_CALLS=0
-	CJICONF_CALL1_ARG4=
-	EXEC_FLV_CALLS=0
-	EXEC_FLV_CALL1_ARG2=
-	HELP_CALLS=0
-	ISVNETAVAIL_CALLS=0
-	ISPOTNETAVAIL_CALLS=0
-	POTNET_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/create2.sh
+++ b/tests/create2.sh
@@ -73,150 +73,193 @@ test_cj_zfs_001()
 	# level 0
 	_c_zfs_multi new-pot 0 11.1
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "1" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL1_ARG2"
-	assertEquals "chmod calls" "0" "$CHMOD_CALLS"
+	assertEqualsMon "zfs calls" "1" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
+	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
 }
 
 test_cj_zfs_002()
 {
 	_c_zfs_multi new-pot 1 11.1
 	assertEquals "return code" "0" "$?"
-	# unfortunately, all the other zfs command are executed in subshell
-	assertEquals "zfs calls" "3" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "zfs arg1" "destroy" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot/usr.local@1234" "$ZFS_CALL2_ARG2"
-	assertEquals "zfs arg1" "destroy" "$ZFS_CALL3_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom@1234" "$ZFS_CALL3_ARG2"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL1_ARG2"
-	assertEquals "chmod calls" "0" "$CHMOD_CALLS"
+	assertEqualsMon "zfs calls" "9" ZFS_CALLS
+	assertEqualsMon "zfs c1 arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs c1 arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "zfs c2 arg1" "send" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs c2 arg2" "${POT_ZFS_ROOT}/bases/11.1/usr.local@1234" ZFS_CALL2_ARG2
+	assertEqualsMon "zfs c3 arg1" "get" ZFS_CALL3_ARG1
+	assertEqualsMon "zfs c3 arg2" "-o" ZFS_CALL3_ARG2
+	assertEqualsMon "zfs c3 arg3" "property" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs c3 arg4" "all" ZFS_CALL3_ARG4
+	assertEqualsMon "zfs c3 arg5" "${POT_ZFS_ROOT}" ZFS_CALL3_ARG5
+	assertEqualsMon "zfs c4 arg1" "receive" ZFS_CALL4_ARG1
+	assertEqualsMon "zfs c4 arg2" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" ZFS_CALL4_ARG2
+	assertEqualsMon "zfs c5 arg1" "destroy" ZFS_CALL5_ARG1
+	assertEqualsMon "zfs c5 arg2" "${POT_ZFS_ROOT}/jails/new-pot/usr.local@1234" ZFS_CALL5_ARG2
+	assertEqualsMon "zfs c6 arg1" "send" ZFS_CALL6_ARG1
+	assertEqualsMon "zfs c6 arg2" "${POT_ZFS_ROOT}/bases/11.1/custom@1234" ZFS_CALL6_ARG2
+	assertEqualsMon "zfs c7 arg1" "get" ZFS_CALL7_ARG1
+	assertEqualsMon "zfs c7 arg2" "-o" ZFS_CALL7_ARG2
+	assertEqualsMon "zfs c7 arg3" "property" ZFS_CALL7_ARG3
+	assertEqualsMon "zfs c7 arg4" "all" ZFS_CALL7_ARG4
+	assertEqualsMon "zfs c7 arg5" "${POT_ZFS_ROOT}" ZFS_CALL7_ARG5
+	assertEqualsMon "zfs c8 arg1" "receive" ZFS_CALL8_ARG1
+	assertEqualsMon "zfs c8 arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL8_ARG2
+	assertEqualsMon "zfs c9 arg1" "destroy" ZFS_CALL9_ARG1
+	assertEqualsMon "zfs c9 arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom@1234" ZFS_CALL9_ARG2
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
+	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
 }
 
 test_cj_zfs_003()
 {
 	_c_zfs_multi new-pot 1 11.1 test-pot
 	assertEquals "return code" "0" "$?"
-	# unfortunately, all the other zfs command are executed in subshell
-	assertEquals "zfs calls" "3" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "zfs arg1" "destroy" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot/usr.local@4321" "$ZFS_CALL2_ARG2"
-	assertEquals "zfs arg1" "destroy" "$ZFS_CALL3_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom@4321" "$ZFS_CALL3_ARG2"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL1_ARG2"
-	assertEquals "chmod calls" "0" "$CHMOD_CALLS"
+	assertEqualsMon "zfs calls" "9" ZFS_CALLS
+	assertEqualsMon "zfs c1 arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs c1 arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "zfs c2 arg1" "send" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs c2 arg2" "${POT_ZFS_ROOT}/jails/test-pot/usr.local@4321" ZFS_CALL2_ARG2
+	assertEqualsMon "zfs c3 arg1" "get" ZFS_CALL3_ARG1
+	assertEqualsMon "zfs c3 arg2" "-o" ZFS_CALL3_ARG2
+	assertEqualsMon "zfs c3 arg3" "property" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs c3 arg4" "all" ZFS_CALL3_ARG4
+	assertEqualsMon "zfs c3 arg5" "${POT_ZFS_ROOT}" ZFS_CALL3_ARG5
+	assertEqualsMon "zfs c4 arg1" "receive" ZFS_CALL4_ARG1
+	assertEqualsMon "zfs c4 arg2" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" ZFS_CALL4_ARG2
+	assertEqualsMon "zfs c5 arg1" "destroy" ZFS_CALL5_ARG1
+	assertEqualsMon "zfs c5 arg2" "${POT_ZFS_ROOT}/jails/new-pot/usr.local@4321" ZFS_CALL5_ARG2
+	assertEqualsMon "zfs c6 arg1" "send" ZFS_CALL6_ARG1
+	assertEqualsMon "zfs c6 arg2" "${POT_ZFS_ROOT}/jails/test-pot/custom@4321" ZFS_CALL6_ARG2
+	assertEqualsMon "zfs c7 arg1" "get" ZFS_CALL7_ARG1
+	assertEqualsMon "zfs c7 arg2" "-o" ZFS_CALL7_ARG2
+	assertEqualsMon "zfs c7 arg3" "property" ZFS_CALL7_ARG3
+	assertEqualsMon "zfs c7 arg4" "all" ZFS_CALL7_ARG4
+	assertEqualsMon "zfs c7 arg5" "${POT_ZFS_ROOT}" ZFS_CALL7_ARG5
+	assertEqualsMon "zfs c8 arg1" "receive" ZFS_CALL8_ARG1
+	assertEqualsMon "zfs c8 arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL8_ARG2
+	assertEqualsMon "zfs c9 arg1" "destroy" ZFS_CALL9_ARG1
+	assertEqualsMon "zfs c9 arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom@4321" ZFS_CALL9_ARG2
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
+	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
 }
 
 test_cj_zfs_004()
 {
 	_c_zfs_multi new-pot 2 11.1 test-pot
 	assertEquals "return code" "0" "$?"
-	# unfortunately, all the other zfs command are executed in subshell
-	assertEquals "zfs calls" "2" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "zfs arg1" "destroy" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom@4321" "$ZFS_CALL2_ARG2"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" "$MKDIR_CALL1_ARG2"
-	assertEquals "chmod calls" "0" "$CHMOD_CALLS"
+	assertEqualsMon "zfs calls" "5" ZFS_CALLS
+	assertEqualsMon "zfs c1 arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs c1 arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "zfs c2 arg1" "send" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs c2 arg2" "${POT_ZFS_ROOT}/jails/test-pot/custom@4321" ZFS_CALL2_ARG2
+	assertEqualsMon "zfs c3 arg1" "get" ZFS_CALL3_ARG1
+	assertEqualsMon "zfs c3 arg2" "-o" ZFS_CALL3_ARG2
+	assertEqualsMon "zfs c3 arg3" "property" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs c3 arg4" "all" ZFS_CALL3_ARG4
+	assertEqualsMon "zfs c3 arg5" "${POT_ZFS_ROOT}" ZFS_CALL3_ARG5
+	assertEqualsMon "zfs c4 arg1" "receive" ZFS_CALL4_ARG1
+	assertEqualsMon "zfs c4 arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL4_ARG2
+	assertEqualsMon "zfs c5 arg1" "destroy" ZFS_CALL5_ARG1
+	assertEqualsMon "zfs c5 arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom@4321" ZFS_CALL5_ARG2
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
+	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
 }
 
 test_cj_zfs_021()
 {
 	_cj_zfs test-pot multi 0 11.1
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "0" "$ZFS_CALLS"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" "$MKDIR_CALL1_ARG2"
-	assertEquals "info calls" "1" "$INFO_CALLS"
-	assertEquals "chmod calls" "0" "$CHMOD_CALLS"
+	assertEqualsMon "zfs calls" "0" ZFS_CALLS
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" MKDIR_CALL1_ARG2
+	assertEqualsMon "info calls" "1" INFO_CALLS
+	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
 }
 
 test_cj_zfs_022()
 {
 	_cj_zfs test-pot multi 1 11.1
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "0" "$ZFS_CALLS"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" "$MKDIR_CALL1_ARG2"
-	assertEquals "info calls" "3" "$INFO_CALLS"
-	assertEquals "chmod calls" "0" "$CHMOD_CALLS"
+	assertEqualsMon "zfs calls" "0" ZFS_CALLS
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" MKDIR_CALL1_ARG2
+	assertEqualsMon "info calls" "3" INFO_CALLS
+	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
 }
 
 test_cj_zfs_023()
 {
 	_cj_zfs test-pot multi 2 11.1 test-pot2
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "0" "$ZFS_CALLS"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" "$MKDIR_CALL1_ARG2"
-	assertEquals "info calls" "2" "$INFO_CALLS"
-	assertEquals "chmod calls" "0" "$CHMOD_CALLS"
+	assertEqualsMon "zfs calls" "0" ZFS_CALLS
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" MKDIR_CALL1_ARG2
+	assertEqualsMon "info calls" "2" INFO_CALLS
+	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
 }
 
 test_cj_zfs_041()
 {
 	_cj_zfs new-pot single 0 11.1
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "2" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot/m" "$ZFS_CALL2_ARG2"
-	assertEquals "mkdir calls" "2" "$MKDIR_CALLS"
-	assertEquals "mkdir 1 arg2" "${POT_FS_ROOT}/jails/new-pot/m/tmp" "$MKDIR_CALL1_ARG2"
-	assertEquals "mkdir 2 arg2" "${POT_FS_ROOT}/jails/new-pot/m/dev" "$MKDIR_CALL2_ARG2"
-	assertEquals "chmod calls" "1" "$CHMOD_CALLS"
-	assertEquals "chmod arg1" "1777" "$CHMOD_CALL1_ARG1"
-	assertEquals "chmod arg2" "${POT_FS_ROOT}/jails/new-pot/m/tmp" "$CHMOD_CALL1_ARG2"
+	assertEqualsMon "zfs calls" "2" ZFS_CALLS
+	assertEqualsMon "zfs c1 arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs c1 arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "zfs c2 arg1" "create" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs c2 arg2" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir 1 arg2" "${POT_FS_ROOT}/jails/new-pot/m/tmp" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir 2 arg2" "${POT_FS_ROOT}/jails/new-pot/m/dev" MKDIR_CALL2_ARG2
+	assertEqualsMon "chmod calls" "1" CHMOD_CALLS
+	assertEqualsMon "chmod arg1" "1777" CHMOD_CALL1_ARG1
+	assertEqualsMon "chmod arg2" "${POT_FS_ROOT}/jails/new-pot/m/tmp" CHMOD_CALL1_ARG2
 }
 
 test_cj_zfs_042()
 {
 	_cj_zfs test-pot single 0 11.1
 	assertEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "1" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/test-pot/m" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "2" "$MKDIR_CALLS"
-	assertEquals "mkdir 1 arg2" "${POT_FS_ROOT}/jails/test-pot/m/tmp" "$MKDIR_CALL1_ARG2"
-	assertEquals "mkdir 2 arg2" "${POT_FS_ROOT}/jails/test-pot/m/dev" "$MKDIR_CALL2_ARG2"
-	assertEquals "chmod calls" "1" "$CHMOD_CALLS"
-	assertEquals "chmod arg1" "1777" "$CHMOD_CALL1_ARG1"
-	assertEquals "chmod arg2" "${POT_FS_ROOT}/jails/test-pot/m/tmp" "$CHMOD_CALL1_ARG2"
+	assertEqualsMon "zfs calls" "1" ZFS_CALLS
+	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/test-pot/m" ZFS_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir 1 arg2" "${POT_FS_ROOT}/jails/test-pot/m/tmp" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir 2 arg2" "${POT_FS_ROOT}/jails/test-pot/m/dev" MKDIR_CALL2_ARG2
+	assertEqualsMon "chmod calls" "1" CHMOD_CALLS
+	assertEqualsMon "chmod arg1" "1777" CHMOD_CALL1_ARG1
+	assertEqualsMon "chmod arg2" "${POT_FS_ROOT}/jails/test-pot/m/tmp" CHMOD_CALL1_ARG2
 }
 
 test_cj_zfs_043()
 {
 	_cj_zfs new-pot single 0 11.1 test-pot
 	assertEquals "return code" "0" "$?"
-	# unfortunately, all the other zfs command are executed in subshell
-	assertEquals "zfs calls" "1" "$ZFS_CALLS"
-	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "mkdir calls" "0" "$MKDIR_CALLS"
-	assertEquals "chmod calls" "0" "$CHMOD_CALLS"
+	assertEqualsMon "zfs calls" "4" ZFS_CALLS
+	assertEqualsMon "zfs c1 arg1" "create" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs c1 arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
+	assertEqualsMon "zfs c2 arg1" "send" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs c2 arg2" "${POT_ZFS_ROOT}/jails/test-pot/m@9999" ZFS_CALL2_ARG2
+	assertEqualsMon "zfs c3 arg1" "get" ZFS_CALL3_ARG1
+	assertEqualsMon "zfs c3 arg2" "-o" ZFS_CALL3_ARG2
+	assertEqualsMon "zfs c3 arg3" "property" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs c3 arg4" "all" ZFS_CALL3_ARG4
+	assertEqualsMon "zfs c3 arg5" "${POT_ZFS_ROOT}" ZFS_CALL3_ARG5
+	assertEqualsMon "zfs c4 arg1" "receive" ZFS_CALL4_ARG1
+	assertEqualsMon "zfs c4 arg2" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL4_ARG2
+	assertEqualsMon "mkdir calls" "0" MKDIR_CALLS
+	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	ZFS_CALLS=0
-	ECHO_CALLS=0
-	MKDIR_CALLS=0
-	CHMOD_CALLS=0
-	ZFSDATASETVALID_CALLS=0
-	ZFSLASTSNAP_CALLS=0
-
 	POT_FS_ROOT=/tmp
 	POT_ZFS_ROOT=zpot
 }

--- a/tests/create3.sh
+++ b/tests/create3.sh
@@ -74,14 +74,14 @@ test_cj_conf_001()
 	assertEquals "network_type" "network_type=inherit" "$(grep ^network_type= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "ip" "" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=false" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "sed calls" "0" "$SED_CALLS"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "0" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "" "$ICONF_CALL1_ARG4"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "sed calls" "0" SED_CALLS
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "0" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "" ICONF_CALL1_ARG4
 }
 
 test_cj_conf_002()
@@ -98,14 +98,14 @@ test_cj_conf_002()
 	assertEquals "network_type" "network_type=inherit" "$(grep ^network_type= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "ip" "" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=false" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "1" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "" "$ICONF_CALL1_ARG4"
-	assertEquals "sed calls" "0" "$SED_CALLS"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "1" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "" ICONF_CALL1_ARG4
+	assertEqualsMon "sed calls" "0" SED_CALLS
 }
 
 test_cj_conf_003()
@@ -127,14 +127,14 @@ test_cj_conf_003()
 	assertEquals "network_type" "network_type=inherit" "$(grep ^network_type= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "ip" "" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=false" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "1" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "" "$ICONF_CALL1_ARG4"
-	assertEquals "sed calls" "0" "$SED_CALLS"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "1" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "" ICONF_CALL1_ARG4
+	assertEqualsMon "sed calls" "0" SED_CALLS
 }
 
 test_cj_conf_004()
@@ -155,14 +155,14 @@ test_cj_conf_004()
 	assertEquals "pot.potbase" "pot.potbase=test-pot" "$(grep ^pot.potbase /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "ip" "" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=false" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "2" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "" "$ICONF_CALL1_ARG4"
-	assertEquals "sed calls" "1" "$SED_CALLS"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "2" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "" ICONF_CALL1_ARG4
+	assertEqualsMon "sed calls" "1" SED_CALLS
 }
 
 test_cj_conf_005()
@@ -179,14 +179,14 @@ test_cj_conf_005()
 	assertEquals "network_type" "network_type=inherit" "$(grep ^network_type= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "ip" "" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=false" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "2" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "" "$ICONF_CALL1_ARG4"
-	assertEquals "sed calls" "0" "$SED_CALLS"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "2" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "" ICONF_CALL1_ARG4
+	assertEqualsMon "sed calls" "0" SED_CALLS
 }
 
 test_cj_conf_006()
@@ -203,14 +203,14 @@ test_cj_conf_006()
 	assertEquals "network_type" "network_type=public-bridge" "$(grep ^network_type= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "ip" "ip=10.1.2.3" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=true" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "1" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "10.1.2.3" "$ICONF_CALL1_ARG4"
-	assertEquals "sed calls" "0" "$SED_CALLS"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "1" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "10.1.2.3" ICONF_CALL1_ARG4
+	assertEqualsMon "sed calls" "0" SED_CALLS
 }
 
 test_cj_conf_007()
@@ -228,14 +228,14 @@ test_cj_conf_007()
 	assertEquals "ip" "" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=false" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.depend" "pot.depend=${POT_DNS_NAME}" "$(grep ^pot.depend /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "sed calls" "0" "$SED_CALLS"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "1" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "" "$ICONF_CALL1_ARG4"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "sed calls" "0" SED_CALLS
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "1" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "" ICONF_CALL1_ARG4
 }
 
 test_cj_conf_008()
@@ -253,14 +253,14 @@ test_cj_conf_008()
 	assertEquals "ip" "ip=10.1.2.3" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=true" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.depend" "pot.depend=${POT_DNS_NAME}" "$(grep ^pot.depend /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "1" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "10.1.2.3" "$ICONF_CALL1_ARG4"
-	assertEquals "sed calls" "0" "$SED_CALLS"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "1" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "10.1.2.3" ICONF_CALL1_ARG4
+	assertEqualsMon "sed calls" "0" SED_CALLS
 }
 
 test_cj_conf_009()
@@ -278,14 +278,14 @@ test_cj_conf_009()
 	assertEquals "ip" "ip=10.1.2.3" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=false" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.depend" "pot.depend=${POT_DNS_NAME}" "$(grep ^pot.depend /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "internal_conf calls" "1" "$ICONF_CALLS"
-	assertEquals "internal_conf arg1" "new-pot" "$ICONF_CALL1_ARG1"
-	assertEquals "internal_conf arg2" "multi" "$ICONF_CALL1_ARG2"
-	assertEquals "internal_conf arg3" "1" "$ICONF_CALL1_ARG3"
-	assertEquals "internal_conf arg4" "10.1.2.3" "$ICONF_CALL1_ARG4"
-	assertEquals "sed calls" "0" "$SED_CALLS"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "internal_conf calls" "1" ICONF_CALLS
+	assertEqualsMon "internal_conf arg1" "new-pot" ICONF_CALL1_ARG1
+	assertEqualsMon "internal_conf arg2" "multi" ICONF_CALL1_ARG2
+	assertEqualsMon "internal_conf arg3" "1" ICONF_CALL1_ARG3
+	assertEqualsMon "internal_conf arg4" "10.1.2.3" ICONF_CALL1_ARG4
+	assertEqualsMon "sed calls" "0" SED_CALLS
 }
 
 test_cj_conf_020()
@@ -303,10 +303,10 @@ test_cj_conf_020()
 	assertEquals "ip" "" "$(grep ^ip= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "vnet" "vnet=false" "$(grep ^vnet= /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.depend" "pot.depend=${POT_DNS_NAME}" "$(grep ^pot.depend /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "mkdir calls" "1" "$MKDIR_CALLS"
-	assertEquals "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" "$MKDIR_CALL1_ARG2"
-	assertEquals "internal_conf calls" "0" "$ICONF_CALLS"
-	assertEquals "sed calls" "0" "$SED_CALLS"
+	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
+	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/conf" MKDIR_CALL1_ARG2
+	assertEqualsMon "internal_conf calls" "0" ICONF_CALLS
+	assertEqualsMon "sed calls" "0" SED_CALLS
 }
 
 test_cj_conf_040()
@@ -318,7 +318,7 @@ test_cj_conf_040()
 	assertEquals "fscomp args3" "" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.dns" "pot.dns=pot" "$(grep ^pot.dns /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.depend" "pot.depend=${POT_DNS_NAME}" "$(grep ^pot.depend /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "cp calls" "0" "$CP_CALLS"
+	assertEqualsMon "cp calls" "0" CP_CALLS
 }
 
 test_cj_conf_041()
@@ -330,7 +330,7 @@ test_cj_conf_041()
 	assertEquals "fscomp args3" "" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.dns" "pot.dns=off" "$(grep ^pot.dns /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.depend" "" "$(grep ^pot.depend /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "cp calls" "0" "$CP_CALLS"
+	assertEqualsMon "cp calls" "0" CP_CALLS
 }
 
 test_cj_conf_042()
@@ -342,7 +342,7 @@ test_cj_conf_042()
 	assertEquals "fscomp args3" "" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.dns" "pot.dns=inherit" "$(grep ^pot.dns /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.depend" "" "$(grep ^pot.depend /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "cp calls" "0" "$CP_CALLS"
+	assertEqualsMon "cp calls" "0" CP_CALLS
 }
 
 test_cj_conf_043()
@@ -354,22 +354,14 @@ test_cj_conf_043()
 	assertEquals "fscomp args3" "" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.dns" "pot.dns=custom" "$(grep ^pot.dns /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.depend" "" "$(grep ^pot.depend /tmp/jails/new-pot/conf/pot.conf)"
-	assertEquals "cp calls" "1" "$CP_CALLS"
-	assertEquals "cp arg1" "/etc/resolv.conf" "$CP_CALL1_ARG1"
-	assertEquals "cp arg2" "/tmp/jails/new-pot/conf/resolv.conf" "$CP_CALL1_ARG2"
+	assertEqualsMon "cp calls" "1" CP_CALLS
+	assertEqualsMon "cp arg1" "/etc/resolv.conf" CP_CALL1_ARG1
+	assertEqualsMon "cp arg2" "/tmp/jails/new-pot/conf/resolv.conf" CP_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	MKDIR_CALLS=0
-	SED_CALLS=0
-	SYSRC_CALLS=0
-	SERVICE_CALLS=0
-	CP_CALLS=0
-	ICONF_CALLS=0
-	ICONF_CALL1_ARG4=
-
 	POT_FS_ROOT=/tmp
 	POT_ZFS_ROOT=zpot
 	POT_DNS_NAME=foobar-dns
@@ -378,6 +370,7 @@ setUp()
 
 tearDown()
 {
+	common_tearDown
 	rm -rf /tmp/jails
 }
 

--- a/tests/destroy1.sh
+++ b/tests/destroy1.sh
@@ -63,102 +63,102 @@ test_pot_destroy_001()
 {
 	pot-destroy
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 
 	setUp
 	pot-destroy -k bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 
 	setUp
 	pot-destroy -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 
 	setUp
 	pot-destroy -va
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_002()
 {
 	pot-destroy -p test-pot -b 11.1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_003()
 {
 	pot-destroy -p test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_004()
 {
 	pot-destroy -p test-pot-0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_005()
 {
 	pot-destroy -p test-pot-2 -f test-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_006()
 {
 	pot-destroy -f test-fscomp -b 11.1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_010()
@@ -166,12 +166,12 @@ test_pot_destroy_010()
 	# error - recursion is needed
 	pot-destroy -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_011()
@@ -179,94 +179,87 @@ test_pot_destroy_011()
 	# error - still running, force is needed
 	pot-destroy -p test-pot-run-2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "1" "$POTDESTROY_CALLS"
-	assertEquals "_pot_zfs_destroy arg1" "test-pot-run-2" "$POTDESTROY_CALL1_ARG1"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "1" POTDESTROY_CALLS
+	assertEqualsMon "_pot_zfs_destroy arg1" "test-pot-run-2" POTDESTROY_CALL1_ARG1
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_020()
 {
 	pot-destroy -p test-pot -r
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "2" "$POTDESTROY_CALLS"
-	assertEquals "_pot_zfs_destroy arg1" "test-pot-2" "$POTDESTROY_CALL1_ARG1"
-	assertEquals "_pot_zfs_destroy arg2" "" "$POTDESTROY_CALL1_ARG2"
-	assertEquals "_pot_zfs_destroy arg1" "test-pot" "$POTDESTROY_CALL2_ARG1"
-	assertEquals "_pot_zfs_destroy arg2" "" "$POTDESTROY_CALL2_ARG2"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "2" POTDESTROY_CALLS
+	assertEqualsMon "_pot_zfs_destroy arg1" "test-pot-2" POTDESTROY_CALL1_ARG1
+	assertEqualsMon "_pot_zfs_destroy arg2" "" POTDESTROY_CALL1_ARG2
+	assertEqualsMon "_pot_zfs_destroy arg1" "test-pot" POTDESTROY_CALL2_ARG1
+	assertEqualsMon "_pot_zfs_destroy arg2" "" POTDESTROY_CALL2_ARG2
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_021()
 {
 	pot-destroy -p test-pot-run-2 -F
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "1" "$POTDESTROY_CALLS"
-	assertEquals "_pot_zfs_destroy arg1" "test-pot-run-2" "$POTDESTROY_CALL1_ARG1"
-	assertEquals "_pot_zfs_destroy arg2" "YES" "$POTDESTROY_CALL1_ARG2"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "1" POTDESTROY_CALLS
+	assertEqualsMon "_pot_zfs_destroy arg1" "test-pot-run-2" POTDESTROY_CALL1_ARG1
+	assertEqualsMon "_pot_zfs_destroy arg2" "YES" POTDESTROY_CALL1_ARG2
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_022()
 {
 	pot-destroy -p test-pot-2
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "1" "$POTDESTROY_CALLS"
-	assertEquals "_pot_zfs_destroy arg1" "test-pot-2" "$POTDESTROY_CALL1_ARG1"
-	assertEquals "_pot_zfs_destroy arg2" "" "$POTDESTROY_CALL1_ARG2"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "1" POTDESTROY_CALLS
+	assertEqualsMon "_pot_zfs_destroy arg1" "test-pot-2" POTDESTROY_CALL1_ARG1
+	assertEqualsMon "_pot_zfs_destroy arg2" "" POTDESTROY_CALL1_ARG2
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_060()
 {
 	pot-destroy -f test-no-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "0" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy arg1" "" "$FSCOMPDESTROY_CALL1_ARG1"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "0" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy arg1" "" FSCOMPDESTROY_CALL1_ARG1
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 
 test_pot_destroy_061()
 {
 	pot-destroy -f test-fscomp
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_destroy calls" "0" "$POTDESTROY_CALLS"
-	assertEquals "_base_zfs_destroy calls" "0" "$BASEDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy calls" "1" "$FSCOMPDESTROY_CALLS"
-	assertEquals "_fscomp_zfs_destroy arg1" "test-fscomp" "$FSCOMPDESTROY_CALL1_ARG1"
-	assertEquals "_zfs_dataset_destroy calls" "0" "$ZFSDDESTROY_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_destroy calls" "0" POTDESTROY_CALLS
+	assertEqualsMon "_base_zfs_destroy calls" "0" BASEDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy calls" "1" FSCOMPDESTROY_CALLS
+	assertEqualsMon "_fscomp_zfs_destroy arg1" "test-fscomp" FSCOMPDESTROY_CALL1_ARG1
+	assertEqualsMon "_zfs_dataset_destroy calls" "0" ZFSDDESTROY_CALLS
 }
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	ZFSDDESTROY_CALLS=0
-	POTDESTROY_CALLS=0
-	POTDESTROY_CALL1_ARG2=""
-	BASEDESTROY_CALLS=0
-	FSCOMPDESTROY_CALLS=0
-	ZFSDATASETVALID_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/export-ports1.sh
+++ b/tests/export-ports1.sh
@@ -23,222 +23,220 @@ test_pot_export_ports_001()
 {
 	pot-export-ports -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 
 	setUp
 	pot-export-ports -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_020()
 {
 	pot-export-ports -p
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_021()
 {
 	pot-export-ports -p ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_022()
 {
 	pot-export-ports -p no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_023()
 {
 	pot-export-ports -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_024()
 {
 	pot-export-ports -e
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_025()
 {
 	pot-export-ports -e ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_026()
 {
 	pot-export-ports -p test-pot -e http
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_027()
 {
 	pot-export-ports -p test-pot -e ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_027()
 {
 	pot-export-ports -p test-pot -e -1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_028()
 {
 	pot-export-ports -p test-pot -e "12 34"
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_029()
 {
 	pot-export-ports -p test-pot -e 65536
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_030()
 {
 	pot-export-ports -p test-pot -e 80:
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_031()
 {
 	pot-export-ports -p test-pot -e :80
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_032()
 {
 	pot-export-ports -p test-pot -e 80:100000
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_ports_033()
 {
 	pot-export-ports -p test-pot -e 100000:80
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 }
 
 #test_pot_export_ports_034()
 #{
 #	pot-export-ports -p test-pot -e 80:80:
 #	assertEquals "Exit rc" "1" "$?"
-#	assertEquals "Help calls" "1" "$HELP_CALLS"
-#	assertEquals "Error calls" "1" "$ERROR_CALLS"
-#	assertEquals "_export_ports calls" "0" "$EXPORTS_CALLS"
+#	assertEqualsMon "Help calls" "1" HELP_CALLS
+#	assertEqualsMon "Error calls" "1" ERROR_CALLS
+#	assertEqualsMon "_export_ports calls" "0" EXPORTS_CALLS
 #}
 
 test_pot_export_ports_040()
 {
 	pot-export-ports -p test-pot-2 -e 80
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export_ports arg1" "test-pot-2" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export_ports arg2" "80" "$EXPORTS_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export_ports arg1" "test-pot-2" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export_ports arg2" "80" EXPORTS_CALL1_ARG2
 }
 
 test_pot_export_ports_041()
 {
 	pot-export-ports -p test-pot-2 -e 80 -e 443
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export_ports arg1" "test-pot-2" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export_ports arg2" "80 443" "$EXPORTS_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export_ports arg1" "test-pot-2" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export_ports arg2" "80 443" EXPORTS_CALL1_ARG2
 }
 
 test_pot_export_ports_042()
 {
 	pot-export-ports -p test-pot-2 -e 80:8080
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export_ports arg1" "test-pot-2" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export_ports arg2" "80:8080" "$EXPORTS_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export_ports arg1" "test-pot-2" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export_ports arg2" "80:8080" EXPORTS_CALL1_ARG2
 }
 
 test_pot_export_ports_043()
 {
 	pot-export-ports -p test-pot-2 -e 80:8080 -e 443:30443
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export_ports arg1" "test-pot-2" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export_ports arg2" "80:8080 443:30443" "$EXPORTS_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export_ports arg1" "test-pot-2" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export_ports arg2" "80:8080 443:30443" EXPORTS_CALL1_ARG2
 }
 
 test_pot_export_ports_044()
 {
 	pot-export-ports -p test-pot-multi-private -e 80:8080 -e 443:30443
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export_ports calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export_ports arg1" "test-pot-multi-private" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export_ports arg2" "80:8080 443:30443" "$EXPORTS_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export_ports calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export_ports arg1" "test-pot-multi-private" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export_ports arg2" "80:8080 443:30443" EXPORTS_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	EXPORTS_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/export1.sh
+++ b/tests/export1.sh
@@ -66,60 +66,60 @@ test_pot_export_001()
 {
 	pot-export -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 
 	setUp
 	pot-export -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_020()
 {
 	pot-export -p
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_021()
 {
 	pot-export -p ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_022()
 {
 	pot-export -p no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_023()
 {
 	pot-export -s
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_024()
 {
 	pot-export -s ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_025()
@@ -127,8 +127,8 @@ test_pot_export_025()
 	# correct snapshot, but no pot
 	pot-export -s 666
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_026()
@@ -136,8 +136,8 @@ test_pot_export_026()
 	# pot is not single
 	pot-export -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_027()
@@ -145,8 +145,8 @@ test_pot_export_027()
 	# snapshot already existing
 	pot-export -p test-pot-single -s 666
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_028()
@@ -154,8 +154,8 @@ test_pot_export_028()
 	# directory doesn't exist
 	pot-export -p test-pot-single -D asdfasdf
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_029()
@@ -163,8 +163,8 @@ test_pot_export_029()
 	# wrong compression level
 	pot-export -p test-pot-single -l max
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_030()
@@ -172,8 +172,8 @@ test_pot_export_030()
 	# wrong compression level
 	pot-export -p test-pot-single -l 10
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_031()
@@ -181,8 +181,8 @@ test_pot_export_031()
 	# wrong number of snapshost
 	pot-export -p test-pot-single-2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_032()
@@ -190,128 +190,121 @@ test_pot_export_032()
 	# no snapshosts available
 	pot-export -p test-pot-single-0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_040()
 {
 	pot-export -p test-pot-single
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_zfs_pot_snap calls" "0" "$ISZFSSNAP_CALLS"
-	assertEquals "_export calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export arg1" "test-pot-single" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export arg2" "1234321" "$EXPORTS_CALL1_ARG2"
-	assertEquals "_export arg3" "1234321" "$EXPORTS_CALL1_ARG3"
-	assertEquals "_export arg4" "" "$EXPORTS_CALL1_ARG4"
-	assertEquals "_export arg5" "." "$EXPORTS_CALL1_ARG5"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_zfs_pot_snap calls" "0" ISZFSSNAP_CALLS
+	assertEqualsMon "_export calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export arg1" "test-pot-single" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export arg2" "1234321" EXPORTS_CALL1_ARG2
+	assertEqualsMon "_export arg3" "1234321" EXPORTS_CALL1_ARG3
+	assertEqualsMon "_export arg4" "" EXPORTS_CALL1_ARG4
+	assertEqualsMon "_export arg5" "." EXPORTS_CALL1_ARG5
 }
 
 test_pot_export_041()
 {
 	pot-export -p test-pot-single -t v1.0
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_zfs_pot_snap calls" "0" "$ISZFSSNAP_CALLS"
-	assertEquals "_export calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export arg1" "test-pot-single" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export arg2" "1234321" "$EXPORTS_CALL1_ARG2"
-	assertEquals "_export arg3" "v1.0" "$EXPORTS_CALL1_ARG3"
-	assertEquals "_export arg4" "" "$EXPORTS_CALL1_ARG4"
-	assertEquals "_export arg5" "." "$EXPORTS_CALL1_ARG5"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_zfs_pot_snap calls" "0" ISZFSSNAP_CALLS
+	assertEqualsMon "_export calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export arg1" "test-pot-single" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export arg2" "1234321" EXPORTS_CALL1_ARG2
+	assertEqualsMon "_export arg3" "v1.0" EXPORTS_CALL1_ARG3
+	assertEqualsMon "_export arg4" "" EXPORTS_CALL1_ARG4
+	assertEqualsMon "_export arg5" "." EXPORTS_CALL1_ARG5
 }
 
 test_pot_export_042()
 {
 	pot-export -p test-pot-single -s 1234
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_043()
 {
 	pot-export -p test-pot-single -s 1234 -t 1.0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_044()
 {
 	pot-export -p test-pot-single -s 1234 -t 1.0 -D /tmp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_export calls" "0" "$EXPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_export calls" "0" EXPORTS_CALLS
 }
 
 test_pot_export_050()
 {
 	pot-export -p test-pot-single-2 -t 1.0 -F
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_zfs_pot_snap calls" "0" "$ISZFSSNAP_CALLS"
-	assertEquals "_export calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export arg1" "test-pot-single-2" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export arg2" "4321234" "$EXPORTS_CALL1_ARG2"
-	assertEquals "_export arg3" "1.0" "$EXPORTS_CALL1_ARG3"
-	assertEquals "_export arg4" "" "$EXPORTS_CALL1_ARG4"
-	assertEquals "_export arg5" "." "$EXPORTS_CALL1_ARG5"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_zfs_pot_snap calls" "0" ISZFSSNAP_CALLS
+	assertEqualsMon "_export calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export arg1" "test-pot-single-2" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export arg2" "4321234" EXPORTS_CALL1_ARG2
+	assertEqualsMon "_export arg3" "1.0" EXPORTS_CALL1_ARG3
+	assertEqualsMon "_export arg4" "" EXPORTS_CALL1_ARG4
+	assertEqualsMon "_export arg5" "." EXPORTS_CALL1_ARG5
 }
 
 test_pot_export_051()
 {
 	pot-export -p test-pot-single-2 -t 1.0 -A
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_zfs_pot_snap calls" "0" "$ISZFSSNAP_CALLS"
-	assertEquals "pot-cmd calls" "1" "$POTCMD_CALLS"
-	assertEquals "pot-cmd arg1" "purge-snapshots" "$POTCMD_CALL1_ARG1"
-	assertEquals "_export calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export arg1" "test-pot-single-2" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export arg2" "4321234" "$EXPORTS_CALL1_ARG2"
-	assertEquals "_export arg3" "1.0" "$EXPORTS_CALL1_ARG3"
-	assertEquals "_export arg4" "" "$EXPORTS_CALL1_ARG4"
-	assertEquals "_export arg5" "." "$EXPORTS_CALL1_ARG5"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_zfs_pot_snap calls" "0" ISZFSSNAP_CALLS
+	assertEqualsMon "pot-cmd calls" "1" POTCMD_CALLS
+	assertEqualsMon "pot-cmd arg1" "purge-snapshots" POTCMD_CALL1_ARG1
+	assertEqualsMon "_export calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export arg1" "test-pot-single-2" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export arg2" "4321234" EXPORTS_CALL1_ARG2
+	assertEqualsMon "_export arg3" "1.0" EXPORTS_CALL1_ARG3
+	assertEqualsMon "_export arg4" "" EXPORTS_CALL1_ARG4
+	assertEqualsMon "_export arg5" "." EXPORTS_CALL1_ARG5
 }
 
 test_pot_export_052()
 {
 	pot-export -p test-pot-single-0 -t 1.0 -A
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_zfs_pot_snap calls" "0" "$ISZFSSNAP_CALLS"
-	assertEquals "pot-cmd calls" "1" "$POTCMD_CALLS"
-	assertEquals "pot-cmd arg1" "snapshot" "$POTCMD_CALL1_ARG1"
-	assertEquals "_export calls" "1" "$EXPORTS_CALLS"
-	assertEquals "_export arg1" "test-pot-single-0" "$EXPORTS_CALL1_ARG1"
-	assertEquals "_export arg2" "123123123" "$EXPORTS_CALL1_ARG2"
-	assertEquals "_export arg3" "1.0" "$EXPORTS_CALL1_ARG3"
-	assertEquals "_export arg4" "" "$EXPORTS_CALL1_ARG4"
-	assertEquals "_export arg5" "." "$EXPORTS_CALL1_ARG5"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_zfs_pot_snap calls" "0" ISZFSSNAP_CALLS
+	assertEqualsMon "pot-cmd calls" "1" POTCMD_CALLS
+	assertEqualsMon "pot-cmd arg1" "snapshot" POTCMD_CALL1_ARG1
+	assertEqualsMon "_export calls" "1" EXPORTS_CALLS
+	assertEqualsMon "_export arg1" "test-pot-single-0" EXPORTS_CALL1_ARG1
+	assertEqualsMon "_export arg2" "123123123" EXPORTS_CALL1_ARG2
+	assertEqualsMon "_export arg3" "1.0" EXPORTS_CALL1_ARG3
+	assertEqualsMon "_export arg4" "" EXPORTS_CALL1_ARG4
+	assertEqualsMon "_export arg5" "." EXPORTS_CALL1_ARG5
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	ISZFSSNAP_CALLS=0
-	ZFSLASTSNAP_CALLS=0
-	EXPORTS_CALLS=0
-	EXPORTS_CALL1_ARG1=""
-	EXPORTS_CALL1_ARG2=""
-	EXPORTS_CALL1_ARG3=""
-	POTCMD_CALLS=0
 }
 
 tearDown()
 {
+	common_tearDown
 	rm -f /tmp/pot_test_last_snap
 }
 

--- a/tests/get-rss1.sh
+++ b/tests/get-rss1.sh
@@ -29,63 +29,59 @@ test_pot_get_rss_001()
 {
 	pot-get-rss
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "print_rss calls" "0" "$PRINT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "print_rss calls" "0" PRINT_CALLS
 
 	setUp
 	pot-get-rss -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "print_rss calls" "0" "$PRINT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "print_rss calls" "0" PRINT_CALLS
 
 	setUp
 	pot-get-rss -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "print_rss calls" "0" "$PRINT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "print_rss calls" "0" PRINT_CALLS
 }
 
 test_pot_get_rss_002()
 {
 	pot-get-rss -p test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "print_rss calls" "0" "$PRINT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "print_rss calls" "0" PRINT_CALLS
 }
 
 test_pot_get_rss_020()
 {
 	pot-get-rss -p test-pot-run
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "print_rss calls" "1" "$PRINT_CALLS"
-	assertEquals "print_rss arg1" "test-pot-run" "$PRINT_CALL1_ARG1"
-	assertEquals "print_rss arg2" "" "$PRINT_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "print_rss calls" "1" PRINT_CALLS
+	assertEqualsMon "print_rss arg1" "test-pot-run" PRINT_CALL1_ARG1
+	assertEqualsMon "print_rss arg2" "" PRINT_CALL1_ARG2
 }
 
 test_pot_get_rss_021()
 {
 	pot-get-rss -p test-pot-run-2 -J
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "print_rss calls" "1" "$PRINT_CALLS"
-	assertEquals "print_rss arg1" "test-pot-run-2" "$PRINT_CALL1_ARG1"
-	assertEquals "print_rss arg2" "YES" "$PRINT_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "print_rss calls" "1" PRINT_CALLS
+	assertEqualsMon "print_rss arg1" "test-pot-run-2" PRINT_CALL1_ARG1
+	assertEqualsMon "print_rss arg2" "YES" PRINT_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	PRINT_CALLS=0
-	PRINT_CALL1_ARG1=
-	PRINT_CALL1_ARG2=
 }
 
 . shunit/shunit2

--- a/tests/import1.sh
+++ b/tests/import1.sh
@@ -30,68 +30,68 @@ test_pot_import_001()
 {
 	pot-import -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 
 	setUp
 	pot-import -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_020()
 {
 	pot-import -p
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_021()
 {
 	pot-import -p ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_022()
 {
 	pot-import -p no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_023()
 {
 	pot-import -t
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_024()
 {
 	pot-import -t ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_025()
@@ -99,90 +99,81 @@ test_pot_import_025()
 	# correct snapshot, but no pot
 	pot-import -t 666
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_026()
 {
 	pot-import -p test-pot-single -t 1.0 -U
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_027()
 {
 	pot-import -p test-pot-single -t 1.0 -U ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_fetch_pot calls" "0" "$FETCHPOT_CALLS"
-	assertEquals "_import calls" "0" "$IMPORTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_fetch_pot calls" "0" FETCHPOT_CALLS
+	assertEqualsMon "_import calls" "0" IMPORTS_CALLS
 }
 
 test_pot_import_040()
 {
 	pot-import -p test-pot-single -t 1.0
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "1" "$FETCHPOT_CALLS"
-	assertEquals "_fetch_pot arg1" "test-pot-single" "$FETCHPOT_CALL1_ARG1"
-	assertEquals "_fetch_pot arg2" "1.0" "$FETCHPOT_CALL1_ARG2"
-	assertEquals "_fetch_pot arg3" "" "$FETCHPOT_CALL1_ARG3"
-	assertEquals "_import calls" "1" "$IMPORTS_CALLS"
-	assertEquals "_import arg1" "test-pot-single" "$IMPORTS_CALL1_ARG1"
-	assertEquals "_import arg2" "1.0" "$IMPORTS_CALL1_ARG2"
-	assertEquals "_import arg3" "test-pot-single_1_0" "$IMPORTS_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "1" FETCHPOT_CALLS
+	assertEqualsMon "_fetch_pot arg1" "test-pot-single" FETCHPOT_CALL1_ARG1
+	assertEqualsMon "_fetch_pot arg2" "1.0" FETCHPOT_CALL1_ARG2
+	assertEqualsMon "_fetch_pot arg3" "" FETCHPOT_CALL1_ARG3
+	assertEqualsMon "_import calls" "1" IMPORTS_CALLS
+	assertEqualsMon "_import arg1" "test-pot-single" IMPORTS_CALL1_ARG1
+	assertEqualsMon "_import arg2" "1.0" IMPORTS_CALL1_ARG2
+	assertEqualsMon "_import arg3" "test-pot-single_1_0" IMPORTS_CALL1_ARG3
 }
 
 test_pot_import_041()
 {
 	pot-import -p test-pot-single -t v1.0
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "1" "$FETCHPOT_CALLS"
-	assertEquals "_fetch_pot arg1" "test-pot-single" "$FETCHPOT_CALL1_ARG1"
-	assertEquals "_fetch_pot arg2" "v1.0" "$FETCHPOT_CALL1_ARG2"
-	assertEquals "_fetch_pot arg3" "" "$FETCHPOT_CALL1_ARG3"
-	assertEquals "_import calls" "1" "$IMPORTS_CALLS"
-	assertEquals "_import arg1" "test-pot-single" "$IMPORTS_CALL1_ARG1"
-	assertEquals "_import arg2" "v1.0" "$IMPORTS_CALL1_ARG2"
-	assertEquals "_import arg3" "test-pot-single_v1_0" "$IMPORTS_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "1" FETCHPOT_CALLS
+	assertEqualsMon "_fetch_pot arg1" "test-pot-single" FETCHPOT_CALL1_ARG1
+	assertEqualsMon "_fetch_pot arg2" "v1.0" FETCHPOT_CALL1_ARG2
+	assertEqualsMon "_fetch_pot arg3" "" FETCHPOT_CALL1_ARG3
+	assertEqualsMon "_import calls" "1" IMPORTS_CALLS
+	assertEqualsMon "_import arg1" "test-pot-single" IMPORTS_CALL1_ARG1
+	assertEqualsMon "_import arg2" "v1.0" IMPORTS_CALL1_ARG2
+	assertEqualsMon "_import arg3" "test-pot-single_v1_0" IMPORTS_CALL1_ARG3
 }
 
 test_pot_import_042()
 {
 	pot-import -p test-pot-single -t 1.0 -U https://example.org
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_fetch_pot calls" "1" "$FETCHPOT_CALLS"
-	assertEquals "_fetch_pot arg1" "test-pot-single" "$FETCHPOT_CALL1_ARG1"
-	assertEquals "_fetch_pot arg2" "1.0" "$FETCHPOT_CALL1_ARG2"
-	assertEquals "_fetch_pot arg3" "https://example.org" "$FETCHPOT_CALL1_ARG3"
-	assertEquals "_import calls" "1" "$IMPORTS_CALLS"
-	assertEquals "_import arg1" "test-pot-single" "$IMPORTS_CALL1_ARG1"
-	assertEquals "_import arg2" "1.0" "$IMPORTS_CALL1_ARG2"
-	assertEquals "_import arg3" "test-pot-single_1_0" "$IMPORTS_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_fetch_pot calls" "1" FETCHPOT_CALLS
+	assertEqualsMon "_fetch_pot arg1" "test-pot-single" FETCHPOT_CALL1_ARG1
+	assertEqualsMon "_fetch_pot arg2" "1.0" FETCHPOT_CALL1_ARG2
+	assertEqualsMon "_fetch_pot arg3" "https://example.org" FETCHPOT_CALL1_ARG3
+	assertEqualsMon "_import calls" "1" IMPORTS_CALLS
+	assertEqualsMon "_import arg1" "test-pot-single" IMPORTS_CALL1_ARG1
+	assertEqualsMon "_import arg2" "1.0" IMPORTS_CALL1_ARG2
+	assertEqualsMon "_import arg3" "test-pot-single_1_0" IMPORTS_CALL1_ARG3
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	IMPORTS_CALLS=0
-	IMPORTS_CALL1_ARG1=""
-	IMPORTS_CALL1_ARG2=""
-	IMPORTS_CALL1_ARG3=""
-	FETCHPOT_CALLS=0
-	FETCHPOT_CALL1_ARG1=""
-	FETCHPOT_CALL1_ARG2=""
-	FETCHPOT_CALL1_ARG3=""
 }
 
 . shunit/shunit2

--- a/tests/info1.sh
+++ b/tests/info1.sh
@@ -12,7 +12,7 @@
 # app specific stubs
 info-help()
 {
-	HELP_CALLS=$(( HELP_CALLS + 1 ))
+	__monitor HELP "$@"
 }
 
 _info_pot()
@@ -34,166 +34,162 @@ test_pot_info_001()
 {
 	pot-info
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
 
 	setUp
 	pot-info -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
 
 	setUp
 	pot-info -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
 
 	setUp
 	pot-info -v
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
 }
 
 test_pot_info_002()
 {
 	pot-info -p test-pot -v -q
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 
 	setUp
 	pot-info -p test-pot -v -q -r
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 }
 
 test_pot_info_003()
 {
 	pot-info -p test-pot -B test-bridge
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 }
 
 test_pot_info_020()
 {
 	pot-info -p
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 
 	setUp
 	pot-info -p not-a-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 }
 
 test_pot_info_021()
 {
 	pot-info -p test-pot -q
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 }
 
 test_pot_info_022()
 {
 	pot-info -p test-pot -qr
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 }
 
 test_pot_info_023()
 {
 	pot-info -p test-pot-run -qr
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 }
 
 test_pot_info_040()
 {
 	pot-info -p test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "1" "$INFOPOT_CALLS"
-	assertEquals "Info arg" "test-pot" "$INFOPOT_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "1" INFOPOT_CALLS
+	assertEqualsMon "Info arg" "test-pot" INFOPOT_CALL1_ARG1
 }
 
 test_pot_info_041()
 {
 	pot-info -p test-pot -v
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "1" "$INFOPOT_CALLS"
-	assertEquals "Info arg" "test-pot" "$INFOPOT_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "1" INFOPOT_CALLS
+	assertEqualsMon "Info arg" "test-pot" INFOPOT_CALL1_ARG1
 }
 
 test_pot_info_042()
 {
 	pot-info -p test-pot -r
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
 }
 
 test_pot_info_043()
 {
 	pot-info -p test-pot -s
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "Info calls" "0" "$INFOPOT_CALLS"
-	assertEquals "InfoSnap calls" "1" "$INFOPOTSNAP_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "Info calls" "0" INFOPOT_CALLS
+	assertEqualsMon "InfoSnap calls" "1" INFOPOTSNAP_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	INFOPOT_CALLS=0
-	INFOPOTENV_CALLS=0
-	INFOPOTSNAP_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/list1.sh
+++ b/tests/list1.sh
@@ -39,226 +39,217 @@ test_pot_list_001()
 {
 	pot-list -k bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 
 	setUp
 	pot-list -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 }
 
 test_pot_list_002()
 {
 	pot-list -pb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 
 	setUp
 	pot-list -bp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 
 	setUp
 	pot-list -ba
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 
 	setUp
 	pot-list -fpF
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 }
 
 test_pot_list_003()
 {
 	pot-list -aq
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 }
 
 test_pot_list_020()
 {
 	pot-list
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "1" "$LSPOTS_CALLS"
-	assertEquals "list_pots args" "" "$LSPOTS_CALL1_ARG1"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "1" LSPOTS_CALLS
+	assertEqualsMon "list_pots args" "" LSPOTS_CALL1_ARG1
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 
 	setUp
 	pot-list -q
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "1" "$LSPOTS_CALLS"
-	assertEquals "list_pots args" "quiet" "$LSPOTS_CALL1_ARG1"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "1" LSPOTS_CALLS
+	assertEqualsMon "list_pots args" "quiet" LSPOTS_CALL1_ARG1
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 }
 
 test_pot_list_021()
 {
 	pot-list -p
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "1" "$LSPOTS_CALLS"
-	assertEquals "list_pots args" "" "$LSPOTS_CALL1_ARG1"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "1" LSPOTS_CALLS
+	assertEqualsMon "list_pots args" "" LSPOTS_CALL1_ARG1
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 
 	setUp
 	pot-list -pq
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "1" "$LSPOTS_CALLS"
-	assertEquals "list_pots args" "quiet" "$LSPOTS_CALL1_ARG1"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "1" LSPOTS_CALLS
+	assertEqualsMon "list_pots args" "quiet" LSPOTS_CALL1_ARG1
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 }
 
 test_pot_list_022()
 {
 	pot-list -b
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "1" "$LSBASES_CALLS"
-	assertEquals "list_bases args" "" "$LSBASES_CALL1_ARG1"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "1" LSBASES_CALLS
+	assertEqualsMon "list_bases args" "" LSBASES_CALL1_ARG1
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 
 	setUp
 	pot-list -bq
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "1" "$LSBASES_CALLS"
-	assertEquals "list_bases args" "quiet" "$LSBASES_CALL1_ARG1"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "1" LSBASES_CALLS
+	assertEqualsMon "list_bases args" "quiet" LSBASES_CALL1_ARG1
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 }
 
 test_pot_list_023()
 {
 	pot-list -f
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "1" "$LSFSCOMP_CALLS"
-	assertEquals "list_fscomp args" "" "$LSFSCOMP_CALL1_ARG1"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "1" LSFSCOMP_CALLS
+	assertEqualsMon "list_fscomp args" "" LSFSCOMP_CALL1_ARG1
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 
 	setUp
 	pot-list -fq
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "1" "$LSFSCOMP_CALLS"
-	assertEquals "list_fscomp args" "quiet" "$LSFSCOMP_CALL1_ARG1"
-	assertEquals "list_flavour calls" "0" "$LSFLAVOUR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "1" LSFSCOMP_CALLS
+	assertEqualsMon "list_fscomp args" "quiet" LSFSCOMP_CALL1_ARG1
+	assertEqualsMon "list_flavour calls" "0" LSFLAVOUR_CALLS
 }
 
 test_pot_list_024()
 {
 	pot-list -F
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "1" "$LSFLAVOUR_CALLS"
-	assertEquals "list_flavour args" "" "$LSFLAVOUR_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "1" LSFLAVOUR_CALLS
+	assertEqualsMon "list_flavour args" "" LSFLAVOUR_CALL1_ARG1
 
 	setUp
 	pot-list -Fq
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "0" "$LSPOTS_CALLS"
-	assertEquals "list_bases calls" "0" "$LSBASES_CALLS"
-	assertEquals "list_fscomp calls" "0" "$LSFSCOMP_CALLS"
-	assertEquals "list_flavour calls" "1" "$LSFLAVOUR_CALLS"
-	assertEquals "list_flavour args" "quiet" "$LSFLAVOUR_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "0" LSPOTS_CALLS
+	assertEqualsMon "list_bases calls" "0" LSBASES_CALLS
+	assertEqualsMon "list_fscomp calls" "0" LSFSCOMP_CALLS
+	assertEqualsMon "list_flavour calls" "1" LSFLAVOUR_CALLS
+	assertEqualsMon "list_flavour args" "quiet" LSFLAVOUR_CALL1_ARG1
 }
 
 test_pot_list_025()
 {
 	pot-list -a
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "list_pots calls" "1" "$LSPOTS_CALLS"
-	assertEquals "list_port args" "" "$LSPOTS_CALL1_ARG1"
-	assertEquals "list_bases calls" "1" "$LSBASES_CALLS"
-	assertEquals "list_bases args" "" "$LSBASES_CALL1_ARG1"
-	assertEquals "list_fscomp calls" "1" "$LSFSCOMP_CALLS"
-	assertEquals "list_fscomp args" "" "$LSFSCOMP_CALL1_ARG1"
-	assertEquals "list_flavour calls" "1" "$LSFLAVOUR_CALLS"
-	assertEquals "list_flavour args" "" "$LSFLAVOUR_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "list_pots calls" "1" LSPOTS_CALLS
+	assertEqualsMon "list_port args" "" LSPOTS_CALL1_ARG1
+	assertEqualsMon "list_bases calls" "1" LSBASES_CALLS
+	assertEqualsMon "list_bases args" "" LSBASES_CALL1_ARG1
+	assertEqualsMon "list_fscomp calls" "1" LSFSCOMP_CALLS
+	assertEqualsMon "list_fscomp args" "" LSFSCOMP_CALL1_ARG1
+	assertEqualsMon "list_flavour calls" "1" LSFLAVOUR_CALLS
+	assertEqualsMon "list_flavour args" "" LSFLAVOUR_CALL1_ARG1
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	LSPOTS_CALLS=0
-	LSPOTS_CALL1_ARG1=
-	LSBASES_CALLS=0
-	LSBASES_CALL1_ARG1=
-	LSFSCOMP_CALLS=0
-	LSFSCOMP_CALL1_ARG1=
-	LSFLAVOUR_CALLS=0
-	LSFLAVOUR_CALL1_ARG1=
 }
 
 . shunit/shunit2

--- a/tests/monitor.sh
+++ b/tests/monitor.sh
@@ -1,14 +1,8 @@
 #!/bin/sh
 
 if [ -z "$POT_MONITOR_TMP" ]; then
-	local p
-	if [ "$(uname)" = "Linux" ]; then
-		p=/dev/shm
-	else
-		p="${TMPDIR:-/tmp}"
-	fi
 	POT_MONITOR_TMP=$(command mktemp \
-	  "${p}/pot-monitor.XXXXXX") || exit 1
+	  "${TMPDIR:-/tmp}/pot-monitor.XXXXXX") || exit 1
 	export POT_MONITOR_TMP
 fi
 

--- a/tests/monitor.sh
+++ b/tests/monitor.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 
 if [ -z "$POT_MONITOR_TMP" ]; then
+	local p
+	if [ "$(uname)" = "Linux" ]; then
+		p=/dev/shm
+	else
+		p="${TMPDIR:-/tmp}"
+	fi
 	POT_MONITOR_TMP=$(command mktemp \
-	  "${TMPDIR:-/tmp}/pot-monitor.XXXXXX") || exit 1
+	  "${p}/pot-monitor.XXXXXX") || exit 1
 	export POT_MONITOR_TMP
 fi
 

--- a/tests/monitor.sh
+++ b/tests/monitor.sh
@@ -1,17 +1,121 @@
 #!/bin/sh
 
-__monitor()
+if [ -z "$POT_MONITOR_TMP" ]; then
+	POT_MONITOR_TMP=$(command mktemp \
+	  "${TMPDIR:-/tmp}/pot-monitor.XXXXXX") || exit 1
+	export POT_MONITOR_TMP
+fi
+
+__mon_put()
+{
+	local k v
+	k="$1"
+	shift
+	v="$*"
+	echo "$k:$(echo "$v" | openssl base64 -A)" >>"$POT_MONITOR_TMP"
+}
+
+__mon_get()
+{
+	local k d r
+	k="$1"
+	d="$2"
+
+	r="$(grep "^$k:" "$POT_MONITOR_TMP" | tail -n1 | \
+		cut -d : -f 2 | openssl base64 -d)"
+
+	if [ -n "$r" ]; then
+		echo "$r"
+	elif [ -n "$d" ]; then
+		echo "$d"
+	fi
+}
+
+__mon_export()
+{
+	local k v line
+
+	while read -r line ; do
+		k="$(echo "$line" | cut -d : -f 1)"
+		v="$(echo "$line" | cut -d : -f 2)"
+		if [ -n "$k" ]; then
+			export "$k"="$(echo "$v" | openssl base64 -d)"
+		fi
+	done < "$POT_MONITOR_TMP"
+}
+
+__mon_init()
+{
+	: >"$POT_MONITOR_TMP" || exit 1
+}
+
+__monitor_int()
 {
 	local M i C
 	i=0
 	M=$1
 	shift
-	eval ${M}_CALLS=\$\(\( ${M}_CALLS + 1 \)\)
-	eval C=\$${M}_CALLS
+	C="$(__mon_get "${M}_CALLS" 0)"
+	C=$(( C + 1 ))
+	__mon_put "${M}_CALLS" "$C"
 	while [ -n "$1" ] || [ -n "$2" ] || [ -n "$3" ]; do
 		i=$(( i + 1 ))
-		eval ${M}_CALL${C}_ARG${i}=\$1
+		__mon_put "${M}_CALL${C}_ARG${i}" "$1"
 		shift
 	done
 }
 
+__monitor()
+{
+	# requires "pkg install flock" on FreebSD
+	(
+		command flock -x -w 10 9
+		__monitor_int "$@"
+	) 9>"$POT_MONITOR_TMP.lock"
+}
+
+__mon_tearDown()
+{
+	if [ -e "$POT_MONITOR_TMP" ]; then
+		command rm "$POT_MONITOR_TMP"
+	fi
+	if [ -e "$POT_MONITOR_TMP.lock" ]; then
+		command rm "$POT_MONITOR_TMP.lock"
+	fi
+}
+
+# $1 name
+# $2 left hand
+# $3 key of right hand mon var
+# $4 default value to compare to
+#    "" defaults to 0 in case key ends on "_CALLS"
+assertEqualsMon()
+{
+	local n l k d
+	n="$1"
+	l="$2"
+	k="$3"
+	d="$4"
+	if [ -z "$d" ] && [ "$k" != "${k%%_CALLS}" ]; then
+		d="0"
+	fi
+	assertEquals "$n" "$l" "$(__mon_get "$k" "$d")"
+}
+
+# $1 name
+# $2 left hand
+# $3 key of right hand mon var
+# $4 default value to compare to
+#    "" defaults to 0 in case key ends on "_CALLS"
+assertNotEqualsMon()
+{
+	local n l k d
+	n="$1"
+	l="$2"
+	k="$3"
+	d="$4"
+	if [ -z "$d" ] && [ "$k" != "${k%%_CALLS}" ]; then
+		d="0"
+	fi
+	assertNotEquals "$n" "$l" "$(__mon_get "$k" "$d")"
+}

--- a/tests/mount-in1.sh
+++ b/tests/mount-in1.sh
@@ -85,512 +85,504 @@ test_pot_mount_in_001()
 {
 	pot-mount-in
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -vb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -b bb
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_002()
 {
 	pot-mount-in -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -f test-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -m /test-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -d /test-dir
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -z zroot/test-dataset
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_003()
 {
 	pot-mount-in -p test-pot -f test-fscomp
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -m /test-mnt -f test-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -m /test-mnt -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_004()
 {
 	pot-mount-in -p test-pot -d /test-dir
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -m /test-mnt -d /test-dir
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -m /test-mnt -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_005()
 {
 	pot-mount-in -p test-pot -z zroot/test-dataset
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -m /test-mnt -z zroot/test-dataset
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -m /test-mnt -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_006()
 {
 	pot-mount-in -p test-pot -m /test-mnt -z zroot/test-dataset -d /test-dir
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-pot -m /test-mnt -z zroot/test-dataset -f test-fscomp
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-pot -m /test-mnt -f test-fscomp -d /test-dir
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_zfs_dataset_valid calls" "0" "$ZDVALID_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_zfs_dataset_valid calls" "0" ZDVALID_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_007()
 {
 	pot-mount-in -p test-no-pot -m /test-no-mnt -f zroot/test-no-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-no-pot -m /test-no-mnt -z test-no-dataset
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-no-pot -m /test-no-mnt -d test-no-dir
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_008()
 {
 	pot-mount-in -p test-no-pot -m /test-no-mnt -f test-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-no-pot -m /test-no-mnt -z zroot/test-dataset
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-no-pot -m /test-no-mnt -d test-dir
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_009()
 {
 	pot-mount-in -p test-pot -f test-fscomp -m test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-pot -d test-dir -m test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-pot -z zroot/test-dataset -m test-no-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_010()
 {
 	pot-mount-in -p test-pot -f test-fscomp -m /
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-pot -d test-dir -m /
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-pot -z zroot/test-dataset -m /
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_011()
 {
 	pot-mount-in -p test-pot -f test-fscomp -m "/mnt/with space"
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-pot -d test-dir -m "/mnt/with space"
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	setUp
 	pot-mount-in -p test-pot -z zroot/test-dataset -m "/mnt/with space"
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 
 	pot-mount-in -p test-pot -f test-fscomp -m "/mnt/space  "
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
 }
 
 test_pot_mount_in_020()
 {
 	pot-mount-in -p test-pot -f test-fscomp -m /test-mnt
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "1" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dataset arg" "zpot/fscomp/test-fscomp" "$MOUNTDSET_CALL1_ARG1"
-	assertEquals "_mount_dataset arg" "test-pot" "$MOUNTDSET_CALL1_ARG2"
-	assertEquals "_mount_dataset arg" "/test-mnt" "$MOUNTDSET_CALL1_ARG3"
-	assertEquals "_mount_dataset arg" "" "$MOUNTDSET_CALL1_ARG4"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "1" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dataset arg" "zpot/fscomp/test-fscomp" MOUNTDSET_CALL1_ARG1
+	assertEqualsMon "_mount_dataset arg" "test-pot" MOUNTDSET_CALL1_ARG2
+	assertEqualsMon "_mount_dataset arg" "/test-mnt" MOUNTDSET_CALL1_ARG3
+	assertEqualsMon "_mount_dataset arg" "" MOUNTDSET_CALL1_ARG4
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
 }
 
 test_pot_mount_in_021()
 {
 	pot-mount-in -p test-pot -f test-fscomp -m /test-mnt -r
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "1" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dataset arg" "zpot/fscomp/test-fscomp" "$MOUNTDSET_CALL1_ARG1"
-	assertEquals "_mount_dataset arg" "test-pot" "$MOUNTDSET_CALL1_ARG2"
-	assertEquals "_mount_dataset arg" "/test-mnt" "$MOUNTDSET_CALL1_ARG3"
-	assertEquals "_mount_dataset arg" "ro" "$MOUNTDSET_CALL1_ARG4"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "1" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dataset arg" "zpot/fscomp/test-fscomp" MOUNTDSET_CALL1_ARG1
+	assertEqualsMon "_mount_dataset arg" "test-pot" MOUNTDSET_CALL1_ARG2
+	assertEqualsMon "_mount_dataset arg" "/test-mnt" MOUNTDSET_CALL1_ARG3
+	assertEqualsMon "_mount_dataset arg" "ro" MOUNTDSET_CALL1_ARG4
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
 }
 
 test_pot_mount_in_022()
 {
 	pot-mount-in -p test-pot -f test-fscomp -m /test-mnt -w
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "1" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dataset arg" "zpot/fscomp/test-fscomp" "$MOUNTDSET_CALL1_ARG1"
-	assertEquals "_mount_dataset arg" "test-pot" "$MOUNTDSET_CALL1_ARG2"
-	assertEquals "_mount_dataset arg" "/test-mnt" "$MOUNTDSET_CALL1_ARG3"
-	assertEquals "_mount_dataset arg" "zfs-remount" "$MOUNTDSET_CALL1_ARG4"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "1" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dataset arg" "zpot/fscomp/test-fscomp" MOUNTDSET_CALL1_ARG1
+	assertEqualsMon "_mount_dataset arg" "test-pot" MOUNTDSET_CALL1_ARG2
+	assertEqualsMon "_mount_dataset arg" "/test-mnt" MOUNTDSET_CALL1_ARG3
+	assertEqualsMon "_mount_dataset arg" "zfs-remount" MOUNTDSET_CALL1_ARG4
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
 }
 test_pot_mount_in_040()
 {
 	pot-mount-in -p test-pot -z zroot/test-dataset -m /test-mnt
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "1" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dataset arg" "zroot/test-dataset" "$MOUNTDSET_CALL1_ARG1"
-	assertEquals "_mount_dataset arg" "test-pot" "$MOUNTDSET_CALL1_ARG2"
-	assertEquals "_mount_dataset arg" "/test-mnt" "$MOUNTDSET_CALL1_ARG3"
-	assertEquals "_mount_dataset arg" "" "$MOUNTDSET_CALL1_ARG4"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "1" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dataset arg" "zroot/test-dataset" MOUNTDSET_CALL1_ARG1
+	assertEqualsMon "_mount_dataset arg" "test-pot" MOUNTDSET_CALL1_ARG2
+	assertEqualsMon "_mount_dataset arg" "/test-mnt" MOUNTDSET_CALL1_ARG3
+	assertEqualsMon "_mount_dataset arg" "" MOUNTDSET_CALL1_ARG4
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
 }
 
 test_pot_mount_in_041()
 {
 	pot-mount-in -p test-pot -z zroot/test-dataset -m /test-mnt -r
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "1" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dataset arg" "zroot/test-dataset" "$MOUNTDSET_CALL1_ARG1"
-	assertEquals "_mount_dataset arg" "test-pot" "$MOUNTDSET_CALL1_ARG2"
-	assertEquals "_mount_dataset arg" "/test-mnt" "$MOUNTDSET_CALL1_ARG3"
-	assertEquals "_mount_dataset arg" "ro" "$MOUNTDSET_CALL1_ARG4"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "1" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dataset arg" "zroot/test-dataset" MOUNTDSET_CALL1_ARG1
+	assertEqualsMon "_mount_dataset arg" "test-pot" MOUNTDSET_CALL1_ARG2
+	assertEqualsMon "_mount_dataset arg" "/test-mnt" MOUNTDSET_CALL1_ARG3
+	assertEqualsMon "_mount_dataset arg" "ro" MOUNTDSET_CALL1_ARG4
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
 }
 
 test_pot_mount_in_042()
 {
 	pot-mount-in -p test-pot -z zroot/test-dataset -m /test-mnt -w
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "1" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dataset arg" "zroot/test-dataset" "$MOUNTDSET_CALL1_ARG1"
-	assertEquals "_mount_dataset arg" "test-pot" "$MOUNTDSET_CALL1_ARG2"
-	assertEquals "_mount_dataset arg" "/test-mnt" "$MOUNTDSET_CALL1_ARG3"
-	assertEquals "_mount_dataset arg" "zfs-remount" "$MOUNTDSET_CALL1_ARG4"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "1" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dataset arg" "zroot/test-dataset" MOUNTDSET_CALL1_ARG1
+	assertEqualsMon "_mount_dataset arg" "test-pot" MOUNTDSET_CALL1_ARG2
+	assertEqualsMon "_mount_dataset arg" "/test-mnt" MOUNTDSET_CALL1_ARG3
+	assertEqualsMon "_mount_dataset arg" "zfs-remount" MOUNTDSET_CALL1_ARG4
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
 }
 
 test_pot_mount_in_060()
 {
 	pot-mount-in -p test-pot -d test-dir -m /test-mnt
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dir calls" "1" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dir arg" "/home/test-dir" "$MOUNTDIR_CALL1_ARG1"
-	assertEquals "_mount_dir arg" "test-pot" "$MOUNTDIR_CALL1_ARG2"
-	assertEquals "_mount_dir arg" "/test-mnt" "$MOUNTDIR_CALL1_ARG3"
-	assertEquals "_mount_dir arg" "" "$MOUNTDIR_CALL1_ARG4"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dir calls" "1" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dir arg" "/home/test-dir" MOUNTDIR_CALL1_ARG1
+	assertEqualsMon "_mount_dir arg" "test-pot" MOUNTDIR_CALL1_ARG2
+	assertEqualsMon "_mount_dir arg" "/test-mnt" MOUNTDIR_CALL1_ARG3
+	assertEqualsMon "_mount_dir arg" "" MOUNTDIR_CALL1_ARG4
 }
 
 test_pot_mount_in_061()
 {
 	pot-mount-in -p test-pot -d test-dir -m /test-mnt -r
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dir calls" "1" "$MOUNTDIR_CALLS"
-	assertEquals "_mount_dir arg" "/home/test-dir" "$MOUNTDIR_CALL1_ARG1"
-	assertEquals "_mount_dir arg" "test-pot" "$MOUNTDIR_CALL1_ARG2"
-	assertEquals "_mount_dir arg" "/test-mnt" "$MOUNTDIR_CALL1_ARG3"
-	assertEquals "_mount_dir arg" "ro" "$MOUNTDIR_CALL1_ARG4"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dir calls" "1" MOUNTDIR_CALLS
+	assertEqualsMon "_mount_dir arg" "/home/test-dir" MOUNTDIR_CALL1_ARG1
+	assertEqualsMon "_mount_dir arg" "test-pot" MOUNTDIR_CALL1_ARG2
+	assertEqualsMon "_mount_dir arg" "/test-mnt" MOUNTDIR_CALL1_ARG3
+	assertEqualsMon "_mount_dir arg" "ro" MOUNTDIR_CALL1_ARG4
 }
 
 test_pot_mount_in_062()
 {
 	pot-mount-in -p test-pot -d test-dir -m /test-mnt -w
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_mount_dataset calls" "0" "$MOUNTDSET_CALLS"
-	assertEquals "_mount_dir calls" "0" "$MOUNTDIR_CALLS"
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_mount_dataset calls" "0" MOUNTDSET_CALLS
+	assertEqualsMon "_mount_dir calls" "0" MOUNTDIR_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	ZDVALID_CALLS=0
-	HELP_CALLS=0
-	MOUNTDIR_CALLS=0
-	MOUNTDSET_CALLS=0
-	MOUNTDSET_CALL1_ARG4=
-	MPVALID_CALLS=0
-	DIRVALID_CALLS=0
-
 	POT_FS_ROOT=/tmp
 	POT_ZFS_ROOT=zpot
 }

--- a/tests/mount-out1.sh
+++ b/tests/mount-out1.sh
@@ -64,79 +64,75 @@ test_pot_mount_in_001()
 {
 	pot-mount-out
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_umount_mnt_p calls" "0" "$UMNT_P_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_umount_mnt_p calls" "0" UMNT_P_CALLS
 
 	setUp
 	pot-mount-out -vb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_umount_mnt_p calls" "0" "$UMNT_P_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_umount_mnt_p calls" "0" UMNT_P_CALLS
 
 	setUp
 	pot-mount-out -b bb
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_umount_mnt_p calls" "0" "$UMNT_P_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_umount_mnt_p calls" "0" UMNT_P_CALLS
 
 	setUp
 	pot-mount-out -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_umount_mnt_p calls" "0" "$UMNT_P_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_umount_mnt_p calls" "0" UMNT_P_CALLS
 }
 
 test_pot_mount_in_002()
 {
 	pot-mount-out -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_umount_mnt_p calls" "0" "$UMNT_P_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_umount_mnt_p calls" "0" UMNT_P_CALLS
 
 	setUp
 	pot-mount-out -m /test-mnt
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "0" "$ISUID0_CALLS"
-	assertEquals "_umount_mnt_p calls" "0" "$UMNT_P_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "0" ISUID0_CALLS
+	assertEqualsMon "_umount_mnt_p calls" "0" UMNT_P_CALLS
 }
 
 test_pot_mount_in_020()
 {
 	pot-mount-out -p test-pot -m /test-mnt
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
-	assertEquals "_umount_mnt_p calls" "1" "$UMNT_P_CALLS"
-	assertEquals "_umount_mnt_p arg" "test-pot" "$UMNT_P_CALL1_ARG1"
-	assertEquals "_umount_mnt_p arg" "/test-mnt" "$UMNT_P_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_uid0 calls" "1" ISUID0_CALLS
+	assertEqualsMon "_umount_mnt_p calls" "1" UMNT_P_CALLS
+	assertEqualsMon "_umount_mnt_p arg" "test-pot" UMNT_P_CALL1_ARG1
+	assertEqualsMon "_umount_mnt_p arg" "/test-mnt" UMNT_P_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	MPVALID_CALLS=0
-	UMNT_P_CALLS=0
-
 	POT_FS_ROOT=/tmp
 	POT_ZFS_ROOT=zpot
 }

--- a/tests/ps1.sh
+++ b/tests/ps1.sh
@@ -29,44 +29,41 @@ test_pot_ps_001()
 {
 	pot-ps -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "ps_pots calls" "0" "$PSPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "ps_pots calls" "0" PSPOTS_CALLS
 
 	setUp
 	pot-ps -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "ps_pots calls" "0" "$PSPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "ps_pots calls" "0" PSPOTS_CALLS
 }
 
 test_pot_ps_020()
 {
 	pot-ps -q
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "ps_pots calls" "1" "$PSPOTS_CALLS"
-	assertEquals "ps_pots arg1" "quiet" "$PSPOTS_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "ps_pots calls" "1" PSPOTS_CALLS
+	assertEqualsMon "ps_pots arg1" "quiet" PSPOTS_CALL1_ARG1
 }
 
 test_pot_ps_021()
 {
 	pot-ps
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "ps_pots calls" "1" "$PSPOTS_CALLS"
-	assertEquals "ps_pots arg1" "" "$PSPOTS_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "ps_pots calls" "1" PSPOTS_CALLS
+	assertEqualsMon "ps_pots arg1" "" PSPOTS_CALL1_ARG1
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	PSPOTS_CALLS=0
-	PSPOTS_CALL1_ARG1=
 }
 
 . shunit/shunit2

--- a/tests/rename1.sh
+++ b/tests/rename1.sh
@@ -33,137 +33,133 @@ test_pot_rename_001()
 {
 	pot-rename
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 
 	setUp
 	pot-rename -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 
 	setUp
 	pot-rename -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 
 	setUp
 	pot-rename -va
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 }
 
 test_pot_rename_002()
 {
 	pot-rename -p test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 
 	setUp
 	pot-rename -n test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 }
 
 test_pot_rename_003()
 {
 	pot-rename -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 
 	setUp
 	pot-rename -n test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 }
 
 test_pot_rename_004()
 {
 	pot-rename -p test-pot -n test-pot-2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 }
 
 test_pot_rename_005()
 {
 	pot-rename -p no-test-pot -n no-test-pot-2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 }
 
 test_pot_rename_006()
 {
 	pot-rename -p test-pot-run -n test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "0" "$RNCONF_CALLS"
-	assertEquals "_rn_zfs calls" "0" "$RNZFS_CALLS"
-	assertEquals "_rn_recursive calls" "0" "$RNRECURSIVE_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "0" RNCONF_CALLS
+	assertEqualsMon "_rn_zfs calls" "0" RNZFS_CALLS
+	assertEqualsMon "_rn_recursive calls" "0" RNRECURSIVE_CALLS
 }
 
 test_pot_rename_020()
 {
 	pot-rename -p test-pot -n test-no-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_rn_conf calls" "1" "$RNCONF_CALLS"
-	assertEquals "_rn_conf args" "test-pot" "$RNCONF_CALL1_ARG1"
-	assertEquals "_rn_conf args" "test-no-pot" "$RNCONF_CALL1_ARG2"
-	assertEquals "_rn_zfs calls" "1" "$RNZFS_CALLS"
-	assertEquals "_rn_zfs args" "test-pot" "$RNZFS_CALL1_ARG1"
-	assertEquals "_rn_zfs args" "test-no-pot" "$RNZFS_CALL1_ARG2"
-	assertEquals "_rn_recursive calls" "1" "$RNRECURSIVE_CALLS"
-	assertEquals "_rn_recursive args" "test-pot" "$RNRECURSIVE_CALL1_ARG1"
-	assertEquals "_rn_recursive args" "test-no-pot" "$RNRECURSIVE_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_rn_conf calls" "1" RNCONF_CALLS
+	assertEqualsMon "_rn_conf args" "test-pot" RNCONF_CALL1_ARG1
+	assertEqualsMon "_rn_conf args" "test-no-pot" RNCONF_CALL1_ARG2
+	assertEqualsMon "_rn_zfs calls" "1" RNZFS_CALLS
+	assertEqualsMon "_rn_zfs args" "test-pot" RNZFS_CALL1_ARG1
+	assertEqualsMon "_rn_zfs args" "test-no-pot" RNZFS_CALL1_ARG2
+	assertEqualsMon "_rn_recursive calls" "1" RNRECURSIVE_CALLS
+	assertEqualsMon "_rn_recursive args" "test-pot" RNRECURSIVE_CALL1_ARG1
+	assertEqualsMon "_rn_recursive args" "test-no-pot" RNRECURSIVE_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	RNCONF_CALLS=0
-	RNZFS_CALLS=0
-	RNRECURSIVE_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/rename2.sh
+++ b/tests/rename2.sh
@@ -41,6 +41,7 @@ setUp()
 
 tearDown()
 {
+	common_tearDown
 	conf_tearDown
 }
 . shunit/shunit2

--- a/tests/rename3.sh
+++ b/tests/rename3.sh
@@ -4,7 +4,6 @@
 zfs()
 {
 	__monitor ZFS "$@"
-
 }
 
 # UUT
@@ -16,16 +15,16 @@ zfs()
 _zfs_dataset_valid()
 {
 	__monitor ZDVALID "$@"
-	case "$1" in 
-		zpot/jails/test-pot|\
-		zpot/jails/test-pot/usr.local|\
-		zpot/jails/test-pot/custom|\
-		zpot/jails/test-pot-2|\
-		zpot/jails/test-pot-2/custom|\
-		zpot/jails/new-pot/usr.local|\
-		zpot/jails/test-pot-single|\
-		zpot/jails/test-pot-single/m|\
-		zpot/jails/new-pot-single/m)
+	case "$1" in
+		${POT_ZFS_ROOT}/jails/test-pot|\
+		${POT_ZFS_ROOT}/jails/test-pot/usr.local|\
+		${POT_ZFS_ROOT}/jails/test-pot/custom|\
+		${POT_ZFS_ROOT}/jails/test-pot-2|\
+		${POT_ZFS_ROOT}/jails/test-pot-2/custom|\
+		${POT_ZFS_ROOT}/jails/new-pot/usr.local|\
+		${POT_ZFS_ROOT}/jails/test-pot-single|\
+		${POT_ZFS_ROOT}/jails/test-pot-single/m|\
+		${POT_ZFS_ROOT}/jails/new-pot-single/m)
 			return 0 # true
 			;;
 	esac
@@ -37,53 +36,83 @@ _zfs_dataset_valid()
 test_rn_zfs_001()
 {
 	_rn_zfs test-pot new-pot
-	assertEquals "_zfs_dataset_valid calls" "4" "${ZDVALID_CALLS}"
-	assertEquals "zfs calls" "9" "${ZFS_CALLS}"
-	assertEquals "zfs c1 args" "umount" "${ZFS_CALL1_ARG1}"
-	assertEquals "zfs c1 args" "zpot/jails/test-pot/usr.local" "${ZFS_CALL1_ARG3}"
-	assertEquals "zfs c3 args" "umount" "${ZFS_CALL3_ARG1}"
-	assertEquals "zfs c3 args" "zpot/jails/test-pot/custom" "${ZFS_CALL3_ARG3}"
-	assertEquals "zfs c5 args" "umount" "${ZFS_CALL5_ARG1}"
-	assertEquals "zfs c5 args" "zpot/jails/test-pot" "${ZFS_CALL5_ARG3}"
-	assertEquals "zfs c6 args" "rename" "${ZFS_CALL6_ARG1}"
-	assertEquals "zfs c6 args" "zpot/jails/test-pot" "${ZFS_CALL6_ARG2}"
-	assertEquals "zfs c6 args" "zpot/jails/new-pot" "${ZFS_CALL6_ARG3}"
+	assertEqualsMon "_zfs_dataset_valid calls" "4" ZDVALID_CALLS
+	assertEqualsMon "zfs calls" "9" ZFS_CALLS
+	assertEqualsMon "zfs c1 arg1" "umount" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs c1 arg2" "-f" ZFS_CALL1_ARG2
+	assertEqualsMon "zfs c1 arg3" "${POT_ZFS_ROOT}/jails/test-pot/usr.local" ZFS_CALL1_ARG3
+	assertEqualsMon "zfs c2 arg1" "set" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs c2 arg2" "mountpoint=/jails/new-pot/usr.local" ZFS_CALL2_ARG2
+	assertEqualsMon "zfs c2 arg3" "${POT_ZFS_ROOT}/jails/test-pot/usr.local" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs c3 arg1" "umount" ZFS_CALL3_ARG1
+	assertEqualsMon "zfs c3 arg2" "-f" ZFS_CALL3_ARG2
+	assertEqualsMon "zfs c3 arg3" "${POT_ZFS_ROOT}/jails/test-pot/custom" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs c4 arg1" "set" ZFS_CALL4_ARG1
+	assertEqualsMon "zfs c4 arg2" "mountpoint=/jails/new-pot/custom" ZFS_CALL4_ARG2
+	assertEqualsMon "zfs c4 arg3" "${POT_ZFS_ROOT}/jails/test-pot/custom" ZFS_CALL4_ARG3
+	assertEqualsMon "zfs c5 arg1" "umount" ZFS_CALL5_ARG1
+	assertEqualsMon "zfs c5 arg2" "-f" ZFS_CALL5_ARG2
+	assertEqualsMon "zfs c5 arg3" "${POT_ZFS_ROOT}/jails/test-pot" ZFS_CALL5_ARG3
+	assertEqualsMon "zfs c6 arg1" "rename" ZFS_CALL6_ARG1
+	assertEqualsMon "zfs c6 arg2" "${POT_ZFS_ROOT}/jails/test-pot" ZFS_CALL6_ARG2
+	assertEqualsMon "zfs c6 arg3" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL6_ARG3
+	assertEqualsMon "zfs c7 arg1" "mount" ZFS_CALL7_ARG1
+	assertEqualsMon "zfs c7 arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL7_ARG2
+	assertEqualsMon "zfs c8 arg1" "mount" ZFS_CALL8_ARG1
+	assertEqualsMon "zfs c8 arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL8_ARG2
+	assertEqualsMon "zfs c9 arg1" "mount" ZFS_CALL9_ARG1
+	assertEqualsMon "zfs c9 arg2" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" ZFS_CALL9_ARG2
 }
 
 test_rn_zfs_002()
 {
 	_rn_zfs test-pot-2 new-pot-2
-	assertEquals "_zfs_dataset_valid calls" "4" "${ZDVALID_CALLS}"
-	assertEquals "zfs calls" "6" "${ZFS_CALLS}"
-	assertEquals "zfs c1 args" "umount" "${ZFS_CALL1_ARG1}"
-	assertEquals "zfs c1 args" "zpot/jails/test-pot-2/custom" "${ZFS_CALL1_ARG3}"
-	assertEquals "zfs c3 args" "umount" "${ZFS_CALL3_ARG1}"
-	assertEquals "zfs c3 args" "zpot/jails/test-pot-2" "${ZFS_CALL3_ARG3}"
-	assertEquals "zfs c4 args" "rename" "${ZFS_CALL4_ARG1}"
-	assertEquals "zfs c4 args" "zpot/jails/test-pot-2" "${ZFS_CALL4_ARG2}"
-	assertEquals "zfs c4 args" "zpot/jails/new-pot-2" "${ZFS_CALL4_ARG3}"
+	assertEqualsMon "_zfs_dataset_valid calls" "4" ZDVALID_CALLS
+	assertEqualsMon "zfs calls" "6" ZFS_CALLS
+	assertEqualsMon "zfs c1 arg1" "umount" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs c1 arg2" "-f" ZFS_CALL1_ARG2
+	assertEqualsMon "zfs c1 arg3" "${POT_ZFS_ROOT}/jails/test-pot-2/custom" ZFS_CALL1_ARG3
+	assertEqualsMon "zfs c2 arg1" "set" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs c2 arg2" "mountpoint=/jails/new-pot-2/custom" ZFS_CALL2_ARG2
+	assertEqualsMon "zfs c2 arg3" "${POT_ZFS_ROOT}/jails/test-pot-2/custom" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs c3 arg1" "umount" ZFS_CALL3_ARG1
+	assertEqualsMon "zfs c3 arg2" "-f" ZFS_CALL3_ARG2
+	assertEqualsMon "zfs c3 arg3" "${POT_ZFS_ROOT}/jails/test-pot-2" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs c4 arg1" "rename" ZFS_CALL4_ARG1
+	assertEqualsMon "zfs c4 arg2" "${POT_ZFS_ROOT}/jails/test-pot-2" ZFS_CALL4_ARG2
+	assertEqualsMon "zfs c4 arg3" "${POT_ZFS_ROOT}/jails/new-pot-2" ZFS_CALL4_ARG3
+	assertEqualsMon "zfs c5 arg1" "mount" ZFS_CALL5_ARG1
+	assertEqualsMon "zfs c5 arg2" "${POT_ZFS_ROOT}/jails/new-pot-2" ZFS_CALL5_ARG2
+	assertEqualsMon "zfs c6 arg1" "mount" ZFS_CALL6_ARG1
+	assertEqualsMon "zfs c6 arg2" "${POT_ZFS_ROOT}/jails/new-pot-2/custom" ZFS_CALL6_ARG2
 }
 
 test_rn_zfs_003()
 {
 	_rn_zfs test-pot-single new-pot-single
-	assertEquals "_zfs_dataset_valid calls" "3" "${ZDVALID_CALLS}"
-	assertEquals "zfs calls" "6" "${ZFS_CALLS}"
-	assertEquals "zfs c1 args" "umount" "${ZFS_CALL1_ARG1}"
-	assertEquals "zfs c1 args" "zpot/jails/test-pot-single/m" "${ZFS_CALL1_ARG3}"
-	assertEquals "zfs c3 args" "umount" "${ZFS_CALL3_ARG1}"
-	assertEquals "zfs c3 args" "zpot/jails/test-pot-single" "${ZFS_CALL3_ARG3}"
-	assertEquals "zfs c4 args" "rename" "${ZFS_CALL4_ARG1}"
-	assertEquals "zfs c4 args" "zpot/jails/test-pot-single" "${ZFS_CALL4_ARG2}"
-	assertEquals "zfs c4 args" "zpot/jails/new-pot-single" "${ZFS_CALL4_ARG3}"
+	assertEqualsMon "_zfs_dataset_valid calls" "3" ZDVALID_CALLS
+	assertEqualsMon "zfs calls" "6" ZFS_CALLS
+	assertEqualsMon "zfs c1 arg1" "umount" ZFS_CALL1_ARG1
+	assertEqualsMon "zfs c1 arg2" "-f" ZFS_CALL1_ARG2
+	assertEqualsMon "zfs c1 arg3" "${POT_ZFS_ROOT}/jails/test-pot-single/m" ZFS_CALL1_ARG3
+	assertEqualsMon "zfs c2 arg1" "set" ZFS_CALL2_ARG1
+	assertEqualsMon "zfs c2 arg2" "mountpoint=/jails/new-pot-single/m" ZFS_CALL2_ARG2
+	assertEqualsMon "zfs c2 arg3" "${POT_ZFS_ROOT}/jails/test-pot-single/m" ZFS_CALL2_ARG3
+	assertEqualsMon "zfs c3 arg1" "umount" ZFS_CALL3_ARG1
+	assertEqualsMon "zfs c3 arg2" "-f" ZFS_CALL3_ARG2
+	assertEqualsMon "zfs c3 arg3" "${POT_ZFS_ROOT}/jails/test-pot-single" ZFS_CALL3_ARG3
+	assertEqualsMon "zfs c4 arg1" "rename" ZFS_CALL4_ARG1
+	assertEqualsMon "zfs c4 arg2" "${POT_ZFS_ROOT}/jails/test-pot-single" ZFS_CALL4_ARG2
+	assertEqualsMon "zfs c4 arg3" "${POT_ZFS_ROOT}/jails/new-pot-single" ZFS_CALL4_ARG3
+	assertEqualsMon "zfs c5 arg1" "mount" ZFS_CALL5_ARG1
+	assertEqualsMon "zfs c5 arg2" "${POT_ZFS_ROOT}/jails/new-pot-single" ZFS_CALL5_ARG2
+	assertEqualsMon "zfs c6 arg1" "mount" ZFS_CALL6_ARG1
+	assertEqualsMon "zfs c6 arg2" "${POT_ZFS_ROOT}/jails/new-pot-single/m" ZFS_CALL6_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	ZFS_CALLS=0
-	ZDVALID_CALLS=0
-
 	POT_ZFS_ROOT=zpot
 }
 

--- a/tests/rename4.sh
+++ b/tests/rename4.sh
@@ -47,6 +47,7 @@ setUp()
 
 tearDown()
 {
+	common_tearDown
 	conf_tearDown
 }
 

--- a/tests/revert1.sh
+++ b/tests/revert1.sh
@@ -11,218 +11,210 @@
 # app specific stubs
 revert-help()
 {
-	HELP_CALLS=$(( HELP_CALLS + 1 ))
+	__monitor HELP "$@"
 }
 
 _pot_zfs_rollback()
 {
-	POTZFSROLL_CALLS=$(( POTZFSROLL_CALLS + 1 ))
-	POTZFSROLL_CALL1_ARG1=$1
+	__monitor POTZFSROLL "$@"
 }
 
 _pot_zfs_rollback_full()
 {
-	POTZFSROLLFULL_CALLS=$(( POTZFSROLLFULL_CALLS + 1 ))
-	POTZFSROLLFULL_CALL1_ARG1=$1
+	__monitor POTZFSROLLFULL "$@"
 }
 
 _fscomp_zfs_rollback()
 {
-	FSCOMPZFSROLL_CALLS=$(( FSCOMPZFSROLL_CALLS + 1 ))
-	FSCOMPZFSROLL_CALL1_ARG1=$1
+	__monitor FSCOMPZFSROLL "$@"
 }
 
 test_pot_revert_001()
 {
 	pot-revert
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 
 	setUp
 	pot-revert -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 
 	setUp
 	pot-revert -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 
 	setUp
 	pot-revert -va
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 }
 
 test_pot_revert_002()
 {
 	pot-revert -f test-fscomp -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "Info calls" "0" INFO_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 
 	setUp
 	pot-revert -p test-pot -f test-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "Info calls" "0" INFO_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 }
 
 test_pot_revert_020()
 {
 	pot-revert -p
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 
 	setUp
 	pot-revert -p not-a-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 
 	setUp
 	pot-revert -p test-pot-run
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 }
 
 test_pot_revert_021()
 {
 	pot-revert -p test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "1" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback arg" "test-pot" "$POTZFSROLL_CALL1_ARG1"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "1" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback arg" "test-pot" POTZFSROLL_CALL1_ARG1
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
 }
 
 test_pot_revert_022()
 {
 	pot-revert -p test-pot -a
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_pot_zfs_rollback_full arg" "" "$POTZFSROLLFULL_CALL1_ARG1"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full arg" "" POTZFSROLLFULL_CALL1_ARG1
 }
 
 test_pot_revert_040()
 {
 	pot-revert -f
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
 
 	setUp
 	pot-revert -f not-a-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_zfs_exist calls" "1" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "1" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
 }
 
 test_pot_revert_041()
 {
 	pot-revert -f test-fscomp
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_zfs_exist calls" "1" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "1" "$FSCOMPZFSROLL_CALLS"
-	assertEquals "_fscomp_zfs_rollback arg" "test-fscomp" "$FSCOMPZFSROLL_CALL1_ARG1"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "1" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "1" FSCOMPZFSROLL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback arg" "test-fscomp" FSCOMPZFSROLL_CALL1_ARG1
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 test_pot_revert_042()
 {
 	pot-revert -f test-fscomp -a
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_rollback calls" "0" "$POTZFSROLL_CALLS"
-	assertEquals "_pot_zfs_rollback_full calls" "0" "$POTZFSROLLFULL_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_rollback calls" "0" "$FSCOMPZFSROLL_CALLS"
-	assertEquals "_fscomp_zfs_rollback arg" "" "$FSCOMPZFSROLL_CALL1_ARG1"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_rollback calls" "0" POTZFSROLL_CALLS
+	assertEqualsMon "_pot_zfs_rollback_full calls" "0" POTZFSROLLFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback calls" "0" FSCOMPZFSROLL_CALLS
+	assertEqualsMon "_fscomp_zfs_rollback arg" "" FSCOMPZFSROLL_CALL1_ARG1
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	POTZFSROLL_CALLS=0
-	POTZFSROLLFULL_CALLS=0
-	FSCOMPZFSROLL_CALLS=0
-	FSCOMPZFSROLL_CALL1_ARG1=
 }
 
 . shunit/shunit2

--- a/tests/set-attr1.sh
+++ b/tests/set-attr1.sh
@@ -23,213 +23,208 @@ test_pot_set_attr_001()
 {
 	pot-set-attribute
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 
 	setUp
 	pot-set-attribute -bv
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 
 	setUp
 	pot-set-attribute -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 
 	setUp
 	pot-set-attribute -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 }
 
 test_pot_set_attr_002()
 {
 	pot-set-attribute -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 
 	setUp
 	pot-set-attribute -A start-at-boot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 
 	setUp
 	pot-set-attribute -V ON
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 }
 
 test_pot_set_attr_003()
 {
 	pot-set-attribute -A start-at-boot -V ON
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 
 	setUp
 	pot-set-attribute -p test-pot -A start-at-boot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 
 	setUp
 	pot-set-attribute -p test-pot -V ON
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 }
 
 test_pot_set_attr_004()
 {
 	pot-set-attribute -p test-no-pot -A start-at-boot -V ON
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 }
 
 test_pot_set_attr_005()
 {
 	pot-set-attribute -p test-pot -A not-an-attribute -V ON
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "0" "$SETATTR_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "0" SETATTR_CALLS
 }
 
 test_pot_set_attr_020()
 {
 	pot-set-attribute -p test-pot -A start-at-boot -V ON
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr calls" "1" "$SETATTR_CALLS"
-	assertEquals "_set_attr arg1" "test-pot" "$SETATTR_CALL1_ARG1"
-	assertEquals "_set_attr arg2" "start-at-boot" "$SETATTR_CALL1_ARG2"
-	assertEquals "_set_attr arg3" "ON" "$SETATTR_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr calls" "1" SETATTR_CALLS
+	assertEqualsMon "_set_attr arg1" "test-pot" SETATTR_CALL1_ARG1
+	assertEqualsMon "_set_attr arg2" "start-at-boot" SETATTR_CALL1_ARG2
+	assertEqualsMon "_set_attr arg3" "ON" SETATTR_CALL1_ARG3
 }
 
 test_pot_set_attr_021()
 {
 	pot-set-attribute -p test-pot -A persistent -V ON
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr arg1" "test-pot" "$SETATTR_CALL1_ARG1"
-	assertEquals "_set_attr arg2" "persistent" "$SETATTR_CALL1_ARG2"
-	assertEquals "_set_attr arg3" "ON" "$SETATTR_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr arg1" "test-pot" SETATTR_CALL1_ARG1
+	assertEqualsMon "_set_attr arg2" "persistent" SETATTR_CALL1_ARG2
+	assertEqualsMon "_set_attr arg3" "ON" SETATTR_CALL1_ARG3
 }
 
 test_pot_set_attr_022()
 {
 	pot-set-attribute -p test-pot -A no-rc-script -V ON
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr arg1" "test-pot" "$SETATTR_CALL1_ARG1"
-	assertEquals "_set_attr arg2" "no-rc-script" "$SETATTR_CALL1_ARG2"
-	assertEquals "_set_attr arg3" "ON" "$SETATTR_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr arg1" "test-pot" SETATTR_CALL1_ARG1
+	assertEqualsMon "_set_attr arg2" "no-rc-script" SETATTR_CALL1_ARG2
+	assertEqualsMon "_set_attr arg3" "ON" SETATTR_CALL1_ARG3
 }
 
 test_pot_set_attr_023()
 {
 	pot-set-attribute -p test-pot -A fdescfs -V ON
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr arg1" "test-pot" "$SETATTR_CALL1_ARG1"
-	assertEquals "_set_attr arg2" "fdescfs" "$SETATTR_CALL1_ARG2"
-	assertEquals "_set_attr arg3" "ON" "$SETATTR_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr arg1" "test-pot" SETATTR_CALL1_ARG1
+	assertEqualsMon "_set_attr arg2" "fdescfs" SETATTR_CALL1_ARG2
+	assertEqualsMon "_set_attr arg3" "ON" SETATTR_CALL1_ARG3
 }
 
 test_pot_set_attr_024()
 {
 	pot-set-attribute -p test-pot -A procfs -V ON
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr arg1" "test-pot" "$SETATTR_CALL1_ARG1"
-	assertEquals "_set_attr arg2" "procfs" "$SETATTR_CALL1_ARG2"
-	assertEquals "_set_attr arg3" "ON" "$SETATTR_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr arg1" "test-pot" SETATTR_CALL1_ARG1
+	assertEqualsMon "_set_attr arg2" "procfs" SETATTR_CALL1_ARG2
+	assertEqualsMon "_set_attr arg3" "ON" SETATTR_CALL1_ARG3
 }
 
 test_pot_set_attr_025()
 {
 	pot-set-attribute -p test-pot -A prunable -V ON
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr arg1" "test-pot" "$SETATTR_CALL1_ARG1"
-	assertEquals "_set_attr arg2" "prunable" "$SETATTR_CALL1_ARG2"
-	assertEquals "_set_attr arg3" "ON" "$SETATTR_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr arg1" "test-pot" SETATTR_CALL1_ARG1
+	assertEqualsMon "_set_attr arg2" "prunable" SETATTR_CALL1_ARG2
+	assertEqualsMon "_set_attr arg3" "ON" SETATTR_CALL1_ARG3
 }
 
 test_pot_set_attr_026()
 {
 	pot-set-attribute -p test-pot -A localhost-tunnel -V ON
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr arg1" "test-pot" "$SETATTR_CALL1_ARG1"
-	assertEquals "_set_attr arg2" "localhost-tunnel" "$SETATTR_CALL1_ARG2"
-	assertEquals "_set_attr arg3" "ON" "$SETATTR_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr arg1" "test-pot" SETATTR_CALL1_ARG1
+	assertEqualsMon "_set_attr arg2" "localhost-tunnel" SETATTR_CALL1_ARG2
+	assertEqualsMon "_set_attr arg3" "ON" SETATTR_CALL1_ARG3
 }
 
 test_pot_set_attr_027()
 {
 	pot-set-attribute -p test-pot -A early-start-at-boot -V ON
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_attr arg1" "test-pot" "$SETATTR_CALL1_ARG1"
-	assertEquals "_set_attr arg2" "early-start-at-boot" "$SETATTR_CALL1_ARG2"
-	assertEquals "_set_attr arg3" "ON" "$SETATTR_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_attr arg1" "test-pot" SETATTR_CALL1_ARG1
+	assertEqualsMon "_set_attr arg2" "early-start-at-boot" SETATTR_CALL1_ARG2
+	assertEqualsMon "_set_attr arg3" "ON" SETATTR_CALL1_ARG3
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	SETATTR_CALLS=0
-	SETATTR_CALL1_ARG1=
-	SETATTR_CALL1_ARG2=
-	SETATTR_CALL1_ARG3=
 }
 
 . shunit/shunit2

--- a/tests/set-attr2.sh
+++ b/tests/set-attr2.sh
@@ -47,7 +47,6 @@ test_normalize_true_false_3()
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/set-cmd1.sh
+++ b/tests/set-cmd1.sh
@@ -23,81 +23,79 @@ test_pot_set_cmd_001()
 {
 	pot-set-cmd
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_command calls" "0" "$SETCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_command calls" "0" SETCMD_CALLS
 
 	setUp
 	pot-set-cmd -bv
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_command calls" "0" "$SETCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_command calls" "0" SETCMD_CALLS
 
 	setUp
 	pot-set-cmd -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_command calls" "0" "$SETCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_command calls" "0" SETCMD_CALLS
 
 	setUp
 	pot-set-cmd -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_command calls" "0" "$SETCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_command calls" "0" SETCMD_CALLS
 }
 
 test_pot_set_cmd_002()
 {
 	pot-set-cmd -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_command calls" "0" "$SETCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_command calls" "0" SETCMD_CALLS
 
 	setUp
 	pot-set-cmd -c sh
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_command calls" "0" "$SETCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_command calls" "0" SETCMD_CALLS
 }
 
 test_pot_set_cmd_020()
 {
 	pot-set-cmd -p test-no-pot -c "sh /etc/rc"
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_command calls" "0" "$SETCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_command calls" "0" SETCMD_CALLS
 }
 
 test_pot_set_cmd_040()
 {
 	pot-set-cmd -p test-pot -c "/echo Hello World"
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_command calls" "1" "$SETCMD_CALLS"
-	assertEquals "_set_command arg1" "test-pot" "$SETCMD_CALL1_ARG1"
-	assertEquals "_set_command arg2" "/echo Hello World" "$SETCMD_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_command calls" "1" SETCMD_CALLS
+	assertEqualsMon "_set_command arg1" "test-pot" SETCMD_CALL1_ARG1
+	assertEqualsMon "_set_command arg2" "/echo Hello World" SETCMD_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	SETCMD_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/set-env1.sh
+++ b/tests/set-env1.sh
@@ -33,263 +33,261 @@ test_pot_set_env_001()
 {
 	pot-set-env
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "0" SETENV_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 
 	setUp
 	pot-set-env -bv
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "0" SETENV_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 
 	setUp
 	pot-set-env -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "0" SETENV_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 
 	setUp
 	pot-set-env -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "0" SETENV_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_002()
 {
 	pot-set-env -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "0" SETENV_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 
 	setUp
 	pot-set-env -E VAR=value
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "0" SETENV_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_020()
 {
 	pot-set-env -p test-no-pot -E VAR=value
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "0" SETENV_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_021()
 {
 	pot-set-env -p test-pot -E NOVAR
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "2" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "2" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "0" SETENV_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_040()
 {
 	pot-set-env -p test-pot -E VAR=value
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value"' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_041()
 {
 	pot-set-env -p test-pot -E VAR=value -E VAR2=value2
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
 	assertEquals "_tmpfile length" "2" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value"' "$(sed '1!d' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR2=value2"' "$(sed '2!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_042()
 {
 	pot-set-env -p test-pot -E VAR="value1 value2"
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_043()
 {
 	pot-set-env -p test-pot -E VAR="value1 value2" -E VAR2=value3
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "2" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR2=value3"' "$(sed '2!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_044()
 {
 	pot-set-env -p test-pot -E EMPTYVAR=
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"EMPTYVAR="' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_045()
 {
 	pot-set-env -p test-pot -E VAR="12*"
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=12*"' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_046()
 {
 	pot-set-env -p test-pot -E VAR='12*' -E 'VAR2=?h* '
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "2" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=12*"' "$(sed '1!d' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR2=?h* "' "$(sed '2!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_027()
 {
 	pot-set-env -p test-pot -E VAR='value1 "value2"'
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value1 \"value2\""' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_060()
 {
 	pot-set-env -p test-pot -E "VAR=value1 value2"
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_061()
 {
 	pot-set-env -p test-pot -E VAR="value1 value2"
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_062()
 {
 	pot-set-env -p test-pot -E 'VAR=value1 value2'
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_env_063()
 {
 	pot-set-env -p test-pot -E VAR='value1 value2'
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
-	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_environment calls" "1" SETENV_CALLS
+	assertEqualsMon "_set_environment arg1" "test-pot" SETENV_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
 	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	SETENV_CALLS=0
-	RM_CALLS=0
 	/bin/rm -f /tmp/pot-set-env
 }
 
 tearDown()
 {
+	common_tearDown
 	/bin/rm -f /tmp/pot-set-env
 }
 

--- a/tests/set-env2.sh
+++ b/tests/set-env2.sh
@@ -25,7 +25,7 @@ test_set_environment_000()
 EOF_SETENV
 	_set_environment test-pot /tmp/pot-set-env
 
-	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR=value"' "$(grep ^pot.env /tmp/jails/test-pot/conf/pot.conf)"
 }
 
@@ -37,7 +37,7 @@ test_set_environment_001()
 EOF_SETENV
 	_set_environment test-pot /tmp/pot-set-env
 
-	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR=value"' "$(grep "^pot.env=\"VAR=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR2=value2"' "$(grep "^pot.env=\"VAR2=" /tmp/jails/test-pot/conf/pot.conf)"
 }
@@ -48,7 +48,7 @@ test_set_environment_002()
 "VAR=value1 value2"
 EOF_SETENV
 	_set_environment test-pot /tmp/pot-set-env
-	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR=value1 value2"' "$(grep ^pot.env /tmp/jails/test-pot/conf/pot.conf)"
 }
 
@@ -59,7 +59,7 @@ test_set_environment_003()
 "VAR2=value3"
 EOF_SETENV
 	_set_environment test-pot /tmp/pot-set-env
-	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR=value1 value2"' "$(grep "^pot.env=\"VAR=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR2=value3"' "$(grep "^pot.env=\"VAR2=" /tmp/jails/test-pot/conf/pot.conf)"
 }
@@ -70,7 +70,7 @@ test_set_environment_004()
 "EMPTYVAR="
 EOF_SETENV
 	_set_environment test-pot /tmp/pot-set-env
-	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="EMPTYVAR="' "$(grep ^pot.env /tmp/jails/test-pot/conf/pot.conf)"
 }
 
@@ -80,7 +80,7 @@ test_set_environment_005()
 "VAR=12*"
 EOF_SETENV
 	_set_environment test-pot /tmp/pot-set-env
-	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR=12*"' "$(grep ^pot.env /tmp/jails/test-pot/conf/pot.conf)"
 }
 
@@ -91,7 +91,7 @@ test_set_environment_006()
 "VAR2=?h* "
 EOF_SETENV
 	_set_environment test-pot /tmp/pot-set-env
-	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR=12*"' "$(grep "^pot.env=\"VAR=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR2=?h* "' "$(grep "^pot.env=\"VAR2=" /tmp/jails/test-pot/conf/pot.conf)"
 }
@@ -102,7 +102,7 @@ test_set_environment_007()
 "VAR=value1 \"value2\""
 EOF_SETENV
 	_set_environment test-pot /tmp/pot-set-env
-	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)"
 	assertEquals "pot.env args" 'pot.env="VAR=value1 \"value2\""' "$(grep "^pot.env=\"VAR=" /tmp/jails/test-pot/conf/pot.conf)"
 }
 

--- a/tests/set-hook1.sh
+++ b/tests/set-hook1.sh
@@ -40,173 +40,171 @@ test_pot_set_hook_001()
 {
 	pot-set-hook
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 
 	setUp
 	pot-set-hook -bv
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 
 	setUp
 	pot-set-hook -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 
 	setUp
 	pot-set-hook -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 }
 
 test_pot_set_hook_002()
 {
 	pot-set-hook -s valid_script
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 }
 
 test_pot_set_hook_003()
 {
 	pot-set-hook -p test-pot -s
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 }
 
 test_pot_set_hook_020()
 {
 	pot-set-hook -p test-no-pot -s valid_script
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 }
 
 test_pot_set_hook_021()
 {
 	pot-set-hook -p test-pot -s not_valid_script
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 }
 
 test_pot_set_hook_022()
 {
 	pot-set-hook -p test-pot -S not_valid_script
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 }
 
 test_pot_set_hook_023()
 {
 	pot-set-hook -p test-pot -t not_valid_script
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 }
 
 test_pot_set_hook_024()
 {
 	pot-set-hook -p test-pot -T not_valid_script
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_set_hook calls" "0" "$SETHOOK_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_set_hook calls" "0" SETHOOK_CALLS
 }
 
 test_pot_set_hook_040()
 {
 	pot-set-hook -p test-pot -s valid_script
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "1" "$SETHOOK_CALLS"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL1_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL1_ARG2"
-	assertEquals "_set_hook arg3" "prestart" "$SETHOOK_CALL1_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "1" SETHOOK_CALLS
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL1_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL1_ARG2
+	assertEqualsMon "_set_hook arg3" "prestart" SETHOOK_CALL1_ARG3
 }
 
 test_pot_set_hook_041()
 {
 	pot-set-hook -p test-pot -s valid_script -S valid_script
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "2" "$SETHOOK_CALLS"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL1_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL1_ARG2"
-	assertEquals "_set_hook arg3" "prestart" "$SETHOOK_CALL1_ARG3"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL2_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL2_ARG2"
-	assertEquals "_set_hook arg3" "poststart" "$SETHOOK_CALL2_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "2" SETHOOK_CALLS
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL1_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL1_ARG2
+	assertEqualsMon "_set_hook arg3" "prestart" SETHOOK_CALL1_ARG3
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL2_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL2_ARG2
+	assertEqualsMon "_set_hook arg3" "poststart" SETHOOK_CALL2_ARG3
 }
 
 test_pot_set_hook_042()
 {
 	pot-set-hook -p test-pot -t valid_script -T valid_script
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "2" "$SETHOOK_CALLS"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL1_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL1_ARG2"
-	assertEquals "_set_hook arg3" "prestop" "$SETHOOK_CALL1_ARG3"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL2_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL2_ARG2"
-	assertEquals "_set_hook arg3" "poststop" "$SETHOOK_CALL2_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "2" SETHOOK_CALLS
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL1_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL1_ARG2
+	assertEqualsMon "_set_hook arg3" "prestop" SETHOOK_CALL1_ARG3
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL2_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL2_ARG2
+	assertEqualsMon "_set_hook arg3" "poststop" SETHOOK_CALL2_ARG3
 }
 
 test_pot_set_hook_043()
 {
 	pot-set-hook -p test-pot -t valid_script -T valid_script -s valid_script -S valid_script
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hook calls" "4" "$SETHOOK_CALLS"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL1_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL1_ARG2"
-	assertEquals "_set_hook arg3" "prestart" "$SETHOOK_CALL1_ARG3"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL2_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL2_ARG2"
-	assertEquals "_set_hook arg3" "poststart" "$SETHOOK_CALL2_ARG3"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL3_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL3_ARG2"
-	assertEquals "_set_hook arg3" "prestop" "$SETHOOK_CALL3_ARG3"
-	assertEquals "_set_hook arg1" "test-pot" "$SETHOOK_CALL4_ARG1"
-	assertEquals "_set_hook arg2" "valid_script" "$SETHOOK_CALL4_ARG2"
-	assertEquals "_set_hook arg3" "poststop" "$SETHOOK_CALL4_ARG3"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hook calls" "4" SETHOOK_CALLS
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL1_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL1_ARG2
+	assertEqualsMon "_set_hook arg3" "prestart" SETHOOK_CALL1_ARG3
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL2_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL2_ARG2
+	assertEqualsMon "_set_hook arg3" "poststart" SETHOOK_CALL2_ARG3
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL3_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL3_ARG2
+	assertEqualsMon "_set_hook arg3" "prestop" SETHOOK_CALL3_ARG3
+	assertEqualsMon "_set_hook arg1" "test-pot" SETHOOK_CALL4_ARG1
+	assertEqualsMon "_set_hook arg2" "valid_script" SETHOOK_CALL4_ARG2
+	assertEqualsMon "_set_hook arg3" "poststop" SETHOOK_CALL4_ARG3
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	SETHOOK_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/set-hosts1.sh
+++ b/tests/set-hosts1.sh
@@ -41,189 +41,187 @@ test_pot_set_hosts_001()
 {
 	pot-set-hosts
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 
 	setUp
 	pot-set-hosts -bv
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 
 	setUp
 	pot-set-hosts -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 
 	setUp
 	pot-set-hosts -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_002()
 {
 	pot-set-hosts -H test-pot-2:10.1.2.3
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_003()
 {
 	pot-set-hosts -p test-pot -H
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_020()
 {
 	pot-set-hosts -p test-no-pot -H test-pot-2:10.1.2.3
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_021()
 {
 	pot-set-hosts -p test-pot -H test-pot-2
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "2" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "2" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_022()
 {
 	pot-set-hosts -p test-pot -H test-pot-2:
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_023()
 {
 	pot-set-hosts -p test-pot -H :10.1.2.3
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "0" SETHOSTS_CALLS
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_040()
 {
 	pot-set-hosts -p test-pot -H test-pot-2:10.1.2.3
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
-	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "1" SETHOSTS_CALLS
+	assertEqualsMon "_set_hosts arg1" "test-pot" SETHOSTS_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '10.1.2.3 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_041()
 {
 	pot-set-hosts -p test-pot -H test-pot-2:10.1.2.3 -H test-pot-3:10.1.2.4
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "1" SETHOSTS_CALLS
 	assertEquals "_tmpfile length" "2" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '10.1.2.3 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '10.1.2.4 test-pot-3' "$(sed '2!d' /tmp/pot-set-hosts)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_042()
 {
 	pot-set-hosts -p test-pot -H test-pot-2:fe00::2
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
-	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "1" SETHOSTS_CALLS
+	assertEqualsMon "_set_hosts arg1" "test-pot" SETHOSTS_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" 'fe00::2 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_043()
 {
 	pot-set-hosts -p test-pot -H test-pot-2:::1
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
-	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "1" SETHOSTS_CALLS
+	assertEqualsMon "_set_hosts arg1" "test-pot" SETHOSTS_CALL1_ARG1
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '::1 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 test_pot_set_hosts_044()
 {
 	pot-set-hosts -p test-pot -H test-pot-2:10.1.2.3 -H test-pot-3:10.1.2.4 -H test-pot-4:::1 -H test-pot-5:fe00::2
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
-	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_hosts calls" "1" SETHOSTS_CALLS
+	assertEqualsMon "_set_hosts arg1" "test-pot" SETHOSTS_CALL1_ARG1
 	assertEquals "_tmpfile length" "4" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '10.1.2.3 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '10.1.2.4 test-pot-3' "$(sed '2!d' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '::1 test-pot-4' "$(sed '3!d' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" 'fe00::2 test-pot-5' "$(sed '4!d' /tmp/pot-set-hosts)"
-	assertEquals "_rm calls" "1" "$RM_CALLS"
+	assertEqualsMon "_rm calls" "1" RM_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	SETHOSTS_CALLS=0
-	RM_CALLS=0
 	/bin/rm -f /tmp/pot-set-hosts
 }
 
 tearDown()
 {
+	common_tearDown
 	/bin/rm -f /tmp/pot-set-hosts
 }
 

--- a/tests/set-rss1.sh
+++ b/tests/set-rss1.sh
@@ -23,157 +23,155 @@ test_pot_set_rss_001()
 {
 	pot-set-rss
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -bv
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 }
 
 test_pot_set_rss_002()
 {
 	pot-set-rss -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -C 1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -M 200M
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -M 200M -C 1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 }
 
 test_pot_set_rss_003()
 {
 	pot-set-rss -p test-pot -M 200Megabyte
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -p test-pot -M 10000000T
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -p test-pot -M 00M
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -p test-pot -M 1.5G
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 }
 
 test_pot_set_rss_020()
 {
 	pot-set-rss -p test-no-pot -C 1
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -p test-no-pot -M 200M
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -p test-pot -M 200M -C 0
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "0" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "0" ADDRSS_CALLS
 }
 
 test_pot_set_rss_021()
 {
 	pot-set-rss -p test-pot -M 200M
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "1" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "1" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -p test-pot -C 1
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "1" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "1" ADDRSS_CALLS
 
 	setUp
 	pot-set-rss -p test-pot -C 2 -M 200M
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_set_rss calls" "2" "$ADDRSS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_set_rss calls" "2" ADDRSS_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	ADDRSS_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/show1.sh
+++ b/tests/show1.sh
@@ -34,146 +34,142 @@ test_pot_show_001()
 {
 	pot-show -k bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 
 	setUp
 	pot-show -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_002()
 {
 	pot-show -a -r
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_003()
 {
 	pot-show -a -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_004()
 {
 	pot-show -a -p test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_005()
 {
 	pot-show -r -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_006()
 {
 	pot-show -r -p test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_010()
 {
 	pot-show -p test-no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_020()
 {
 	pot-show
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "1" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "1" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_021()
 {
 	pot-show -r
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "1" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "1" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_022()
 {
 	pot-show -a
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "show_pot calls" "0" "$SHOWPOT_CALLS"
-	assertEquals "show_all_pots calls" "1" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "show_pot calls" "0" SHOWPOT_CALLS
+	assertEqualsMon "show_all_pots calls" "1" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 test_pot_show_023()
 {
 	pot-show -p test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "show_pot calls" "1" "$SHOWPOT_CALLS"
-	assertEquals "show_pot arg" "test-pot" "$SHOWPOT_CALL1_ARG1"
-	assertEquals "show_all_pots calls" "0" "$SHOWALLPOTS_CALLS"
-	assertEquals "show_running_pots calls" "0" "$SHOWRUNPOTS_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "show_pot calls" "1" SHOWPOT_CALLS
+	assertEqualsMon "show_pot arg" "test-pot" SHOWPOT_CALL1_ARG1
+	assertEqualsMon "show_all_pots calls" "0" SHOWALLPOTS_CALLS
+	assertEqualsMon "show_running_pots calls" "0" SHOWRUNPOTS_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	SHOWPOT_CALLS=0
-	SHOWALLPOTS_CALLS=0
-	SHOWRUNPOTS_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/snapshot1.sh
+++ b/tests/snapshot1.sh
@@ -11,306 +11,300 @@
 # app specific stubs
 snapshot-help()
 {
-	HELP_CALLS=$(( HELP_CALLS + 1 ))
+	__monitor HELP "$@"
 }
 
 test_pot_snapshot_001()
 {
 	pot-snapshot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 
 	setUp
 	pot-snapshot -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 
 	setUp
 	pot-snapshot -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 
 	setUp
 	pot-snapshot -va
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 }
 
 test_pot_snapshot_002()
 {
 	pot-snapshot -f test-fscomp -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 test_pot_snapshot_003()
 {
 	pot-snapshot -p test-pot -f test-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 test_pot_snapshot_004()
 {
 	pot-snapshot -p test-pot -n backup
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 test_pot_snapshot_020()
 {
 	pot-snapshot -p
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 
 	setUp
 	pot-snapshot -p not-a-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 
 	setUp
 	pot-snapshot -p test-pot-run
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 }
 
 test_pot_snapshot_021()
 {
 	pot-snapshot -p test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "1" "$POTZFSSNAP_CALLS"
-	assertEquals "_pot_zfs_snap arg" "test-pot" "$POTZFSSNAP_CALL1_ARG1"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "1" POTZFSSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap arg" "test-pot" POTZFSSNAP_CALL1_ARG1
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 }
 
 test_pot_snapshot_022()
 {
 	pot-snapshot -p test-pot -a
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 test_pot_snapshot_023()
 {
 	pot-snapshot -p test-pot -r
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "1" "$RMVPOTSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap arg" "test-pot" "$RMVPOTSNAP_CALL1_ARG1"
-	assertEquals "_pot_zfs_snap calls" "1" "$POTZFSSNAP_CALLS"
-	assertEquals "_pot_zfs_snap arg" "test-pot" "$POTZFSSNAP_CALL1_ARG1"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "1" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "1" RMVPOTSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap arg" "test-pot" RMVPOTSNAP_CALL1_ARG1
+	assertEqualsMon "_pot_zfs_snap calls" "1" POTZFSSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap arg" "test-pot" POTZFSSNAP_CALL1_ARG1
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 }
 
 test_pot_snapshot_040()
 {
 	pot-snapshot -f
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 
 	setUp
 	pot-snapshot -f not-a-fscomp
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "1" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
-	
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "1" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
 }
 
 test_pot_snapshot_041()
 {
 	pot-snapshot -f test-fscomp
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "1" "$ZFSEXIST_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "1" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_fscomp_zfs_snap arg" "test-fscomp" "$FSCOMPZFSSNAP_CALL1_ARG1"
-	assertEquals "_fscomp_zfs_snap arg" "" "$FSCOMPZFSSNAP_CALL1_ARG2"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "1" ZFSEXIST_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "1" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_fscomp_zfs_snap arg" "test-fscomp" FSCOMPZFSSNAP_CALL1_ARG1
+	assertEqualsMon "_fscomp_zfs_snap arg" "" FSCOMPZFSSNAP_CALL1_ARG2
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 test_pot_snapshot_042()
 {
 	pot-snapshot -f test-fscomp -a
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 test_pot_snapshot_043()
 {
 	pot-snapshot -f test-fscomp -n backup
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "0" "$ZFSEXIST_CALLS"
-	assertEquals "_fscomp_zfs_snap calls" "0" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "0" "$RMVFSCOMPSNAP_CALLS"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "0" ZFSEXIST_CALLS
+	assertEqualsMon "_fscomp_zfs_snap calls" "0" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "0" RMVFSCOMPSNAP_CALLS
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 test_pot_snapshot_044()
 {
 	pot-snapshot -f test-fscomp -r
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_pot_zfs_snap calls" "0" "$POTZFSSNAP_CALLS"
-	assertEquals "_remove_oldest_pot_snap calls" "0" "$RMVPOTSNAP_CALLS"
-	assertEquals "_pot_zfs_snap_full calls" "0" "$POTZFSSNAPFULL_CALLS"
-	assertEquals "_zfs_exist calls" "1" "$ZFSEXIST_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap calls" "1" "$RMVFSCOMPSNAP_CALLS"
-	assertEquals "_remove_oldest_fscomp_snap arg" "test-fscomp" "$RMVFSCOMPSNAP_CALL1_ARG1"
-	assertEquals "_fscomp_zfs_snap calls" "1" "$FSCOMPZFSSNAP_CALLS"
-	assertEquals "_fscomp_zfs_snap arg" "test-fscomp" "$FSCOMPZFSSNAP_CALL1_ARG1"
-	assertEquals "_fscomp_zfs_snap arg" "" "$FSCOMPZFSSNAP_CALL1_ARG2"
-	assertEquals "Info calls" "0" "$INFO_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot calls" "0" ISPOT_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_pot_zfs_snap calls" "0" POTZFSSNAP_CALLS
+	assertEqualsMon "_remove_oldest_pot_snap calls" "0" RMVPOTSNAP_CALLS
+	assertEqualsMon "_pot_zfs_snap_full calls" "0" POTZFSSNAPFULL_CALLS
+	assertEqualsMon "_zfs_exist calls" "1" ZFSEXIST_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap calls" "1" RMVFSCOMPSNAP_CALLS
+	assertEqualsMon "_remove_oldest_fscomp_snap arg" "test-fscomp" RMVFSCOMPSNAP_CALL1_ARG1
+	assertEqualsMon "_fscomp_zfs_snap calls" "1" FSCOMPZFSSNAP_CALLS
+	assertEqualsMon "_fscomp_zfs_snap arg" "test-fscomp" FSCOMPZFSSNAP_CALL1_ARG1
+	assertEqualsMon "_fscomp_zfs_snap arg" "" FSCOMPZFSSNAP_CALL1_ARG2
+	assertEqualsMon "Info calls" "0" INFO_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	FSCOMPZFSSNAP_CALL1_ARG1=""
-	FSCOMPZFSSNAP_CALL1_ARG2=""
-	RMVPOTSNAP_CALL1_ARG1=""
-	RMVFSCOMPSNAP_CALL1_ARG1=""
 }
 
 . shunit/shunit2

--- a/tests/start2.sh
+++ b/tests/start2.sh
@@ -65,7 +65,7 @@ _get_pot_export_ports()
 test_js_export_ports_001()
 {
 	_js_export_ports test-pot80
-	assertEquals "pfctl calls" "1" "$PFCTL_CALLS"
+	assertEqualsMon "pfctl calls" "1" PFCTL_CALLS
 	assertEquals "pfrules lines" "1" "$( wc -l $MKTEMP_FILE | awk '{print $1}')"
 	assertEquals "rdr rule" "rdr pass on em2 proto tcp from any to (em2) port 3333 -> 1.2.3.4 port 80" "$(sed '1!d' $MKTEMP_FILE)"
 }
@@ -74,7 +74,7 @@ test_js_export_ports_001()
 test_js_export_ports_002()
 {
 	_js_export_ports test-pot80s3000
-	assertEquals "pfctl calls" "1" "$PFCTL_CALLS"
+	assertEqualsMon "pfctl calls" "1" PFCTL_CALLS
 	assertEquals "pfrules lines" "1" "$( wc -l $MKTEMP_FILE | awk '{print $1}')"
 	assertEquals "rdr rule" "rdr pass on em2 proto tcp from any to (em2) port 3000 -> 1.2.3.4 port 80" "$(sed '1!d' $MKTEMP_FILE)"
 }
@@ -82,7 +82,7 @@ test_js_export_ports_002()
 test_js_export_ports_003()
 {
 	_js_export_ports test-pot80433
-	assertEquals "pfctl calls" "1" "$PFCTL_CALLS"
+	assertEqualsMon "pfctl calls" "1" PFCTL_CALLS
 	assertEquals "pfrules lines" "2" "$( wc -l $MKTEMP_FILE | awk '{print $1}')"
 	assertEquals "rdr rule" "rdr pass on em2 proto tcp from any to (em2) port 3333 -> 1.2.3.4 port 80" "$(sed '1!d' $MKTEMP_FILE)"
 	assertEquals "rdr rule" "rdr pass on em2 proto tcp from any to (em2) port 3000 -> 1.2.3.4 port 433" "$(sed '2!d' $MKTEMP_FILE)"
@@ -91,7 +91,7 @@ test_js_export_ports_003()
 test_js_export_ports_004()
 {
 	_js_export_ports test-pot53udp80433tcp
-	assertEquals "pfctl calls" "1" "$PFCTL_CALLS"
+	assertEqualsMon "pfctl calls" "1" PFCTL_CALLS
 	assertEquals "pfrules lines" "3" "$( wc -l $MKTEMP_FILE | awk '{print $1}')"
 	assertEquals "rdr rule" "rdr pass on em2 proto udp from any to (em2) port 53 -> 1.2.3.4 port 53" "$(sed '1!d' $MKTEMP_FILE)"
 	assertEquals "rdr rule" "rdr pass on em2 proto tcp from any to (em2) port 3333 -> 1.2.3.4 port 80" "$(sed '2!d' $MKTEMP_FILE)"
@@ -100,10 +100,6 @@ test_js_export_ports_004()
 setUp()
 {
 	common_setUp
-	PFCTL_CALLS=0
-	GETEXPORTPORTS_CALLS=0
-	RNDPORT_CALLS=0
-
 	POT_FS_ROOT=/tmp
 	POT_ZFS_ROOT=zpot
 	POT_EXTIF="em2"
@@ -111,6 +107,7 @@ setUp()
 
 tearDown()
 {
+	common_tearDown
 	/bin/rm -f $MKTEMP_FILE
 }
 . shunit/shunit2

--- a/tests/start3.sh
+++ b/tests/start3.sh
@@ -169,6 +169,7 @@ setUp()
 
 tearDown()
 {
+	common_tearDown
 	conf_tearDown
 }
 

--- a/tests/start4.sh
+++ b/tests/start4.sh
@@ -123,6 +123,7 @@ setUp()
 
 tearDown()
 {
+	common_tearDown
 	rm -rf /tmp/jails
 }
 . shunit/shunit2

--- a/tests/stop1.sh
+++ b/tests/stop1.sh
@@ -40,48 +40,46 @@ test_pot_stop_001()
 {
 	pot-stop
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "Stop calls" "0" "$STOPPED_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "Stop calls" "0" STOPPED_CALLS
 
 	setUp
 	pot-stop -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "Stop calls" "0" "$STOPPED_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "Stop calls" "0" STOPPED_CALLS
 
 	setUp
 	pot-stop -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "Stop calls" "0" "$STOPPED_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "Stop calls" "0" STOPPED_CALLS
 }
 
 test_pot_stop_002()
 {
 	pot-stop non-existent-test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "Stop calls" "0" "$STOPPED_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "Stop calls" "0" STOPPED_CALLS
 }
 
 test_pot_stop_020()
 {
 	pot-stop test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "Stop calls" "1" "$STOPPED_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "Stop calls" "1" STOPPED_CALLS
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	STOPPED_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/term1.sh
+++ b/tests/term1.sh
@@ -34,62 +34,62 @@ test_pot_term_001()
 {
 	pot-term
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_term calls" "0" "$TERM_CALLS"
-	assertEquals "pot-cmd calls" "0" "$POTCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_term calls" "0" TERM_CALLS
+	assertEqualsMon "pot-cmd calls" "0" POTCMD_CALLS
 
 	setUp
 	pot-term -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "_term calls" "0" "$TERM_CALLS"
-	assertEquals "pot-cmd calls" "0" "$POTCMD_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "_term calls" "0" TERM_CALLS
+	assertEqualsMon "pot-cmd calls" "0" POTCMD_CALLS
 
 	setUp
 	pot-term -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot_running calls" "0" "$ISPOTRUN_CALLS"
-	assertEquals "_term calls" "0" "$TERM_CALLS"
-	assertEquals "pot-cmd calls" "0" "$POTCMD_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot_running calls" "0" ISPOTRUN_CALLS
+	assertEqualsMon "_term calls" "0" TERM_CALLS
+	assertEqualsMon "pot-cmd calls" "0" POTCMD_CALLS
 }
 
 test_pot_term_020()
 {
 	pot-term test-pot-run
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "_term calls" "1" "$TERM_CALLS"
-	assertEquals "pot-cmd calls" "0" "$POTCMD_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "_term calls" "1" TERM_CALLS
+	assertEqualsMon "pot-cmd calls" "0" POTCMD_CALLS
 }
 
 test_pot_term_030()
 {
 	pot-term test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot_running calls" "1" "$ISPOTRUN_CALLS"
-	assertEquals "_term calls" "0" "$TERM_CALLS"
-	assertEquals "pot-cmd calls" "0" "$POTCMD_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot_running calls" "1" ISPOTRUN_CALLS
+	assertEqualsMon "_term calls" "0" TERM_CALLS
+	assertEqualsMon "pot-cmd calls" "0" POTCMD_CALLS
 }
 
 test_pot_term_031()
 {
 	pot-term -f test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "_is_pot_running calls" "2" "$ISPOTRUN_CALLS"
-	assertEquals "_term calls" "0" "$TERM_CALLS"
-	assertEquals "pot-cmd calls" "1" "$POTCMD_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "_is_pot_running calls" "2" ISPOTRUN_CALLS
+	assertEqualsMon "_term calls" "0" TERM_CALLS
+	assertEqualsMon "pot-cmd calls" "1" POTCMD_CALLS
 }
 
 test_pot_term_032() {
@@ -98,20 +98,17 @@ test_pot_term_032() {
 	POTCMD_SHOULD_START_POT=yes
 	pot-term -f test-pot
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "_is_pot_running calls" "2" "$ISPOTRUN_CALLS"
-	assertEquals "_term calls" "1" "$TERM_CALLS"
-	assertEquals "pot-cmd calls" "1" "$POTCMD_CALLS"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "_is_pot_running calls" "2" ISPOTRUN_CALLS
+	assertEqualsMon "_term calls" "1" TERM_CALLS
+	assertEqualsMon "pot-cmd calls" "1" POTCMD_CALLS
 }
 
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	TERM_CALLS=0
-	POTCMD_CALLS=0
 	POTCMD_SHOULD_START_POT=no
 }
 

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -15,6 +15,15 @@ else
 	echo
 fi
 
+if ! command -v flock >/dev/null; then
+	echo "flock not found." 1>&2
+	if [ "$(uname)" = "FreeBSD" ]; then
+		echo "Consider installing sysutils/flock" 1>&2
+		echo "(pkg install flock)" 1>&2
+	fi
+	exit 1
+fi
+
 suites=$(ls ./*.sh)
 rc=0
 for s in $suites ; do

--- a/tests/top1.sh
+++ b/tests/top1.sh
@@ -24,74 +24,72 @@ test_pot_top_001()
 {
 	pot-top -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "top calls" "0" "$TOP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "top calls" "0" TOP_CALLS
 
 	setUp
 	pot-top -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "top calls" "0" "$TOP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "top calls" "0" TOP_CALLS
 }
 
 test_pot_top_020()
 {
 	pot-top -p
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "top calls" "0" "$TOP_CALLS"
-	assertEquals "top arg1" "" "$TOP_CALL1_ARG1"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "top calls" "0" TOP_CALLS
+	assertEqualsMon "top arg1" "" TOP_CALL1_ARG1
 }
 
 test_pot_top_021()
 {
 	pot-top -p ""
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "top calls" "0" "$TOP_CALLS"
-	assertEquals "top arg1" "" "$TOP_CALL1_ARG1"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "top calls" "0" TOP_CALLS
+	assertEqualsMon "top arg1" "" TOP_CALL1_ARG1
 }
 
 test_pot_top_022()
 {
 	pot-top -p no-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "top calls" "0" "$TOP_CALLS"
-	assertEquals "top arg1" "" "$TOP_CALL1_ARG1"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "top calls" "0" TOP_CALLS
+	assertEqualsMon "top arg1" "" TOP_CALL1_ARG1
 }
 
 test_pot_top_023()
 {
 	pot-top -p test-pot
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
-	assertEquals "Error calls" "1" "$ERROR_CALLS"
-	assertEquals "top calls" "0" "$TOP_CALLS"
-	assertEquals "top arg1" "" "$TOP_CALL1_ARG1"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
+	assertEqualsMon "Error calls" "1" ERROR_CALLS
+	assertEqualsMon "top calls" "0" TOP_CALLS
+	assertEqualsMon "top arg1" "" TOP_CALL1_ARG1
 }
 
 test_pot_top_040()
 {
 	pot-top -p test-pot-run
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "0" "$HELP_CALLS"
-	assertEquals "Error calls" "0" "$ERROR_CALLS"
-	assertEquals "top calls" "1" "$TOP_CALLS"
-	assertEquals "top arg1" "-J" "$TOP_CALL1_ARG1"
-	assertEquals "top arg2" "test-pot-run" "$TOP_CALL1_ARG2"
+	assertEqualsMon "Help calls" "0" HELP_CALLS
+	assertEqualsMon "Error calls" "0" ERROR_CALLS
+	assertEqualsMon "top calls" "1" TOP_CALLS
+	assertEqualsMon "top arg1" "-J" TOP_CALL1_ARG1
+	assertEqualsMon "top arg2" "test-pot-run" TOP_CALL1_ARG2
 }
 
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
-	TOP_CALLS=0
 }
 
 . shunit/shunit2

--- a/tests/version1.sh
+++ b/tests/version1.sh
@@ -19,12 +19,12 @@ test_pot_version_001()
 {
 	pot-version -b bb
 	assertEquals "Exit rc" "1" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
 
 	setUp
 	pot-version -h
 	assertEquals "Exit rc" "0" "$?"
-	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEqualsMon "Help calls" "1" HELP_CALLS
 }
 
 test_pot_version_020()
@@ -51,7 +51,6 @@ test_pot_version_022()
 setUp()
 {
 	common_setUp
-	HELP_CALLS=0
 	_POT_VERSION="5.4.3"
 	_POT_VERBOSITY="1"
 


### PR DESCRIPTION
This is done by storing key/values in a temporary file instead
of shell variables.

This allows thorough testing of command sequences, especially
tests like create2.sh profit from this.

Requires sysutils/flock when running on FreeBSD.