### PR TITLE
Fix pot internal state in start-cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.15.1] 2022-09-16
 ### Fixed
-- set-status: fix a bug that delete the status (#224)
+- set-status: fix a bug that deletes the status (#224)
+- start: fix pot getting stuck in state "starting" on pot start failure (#227)
 
 ## [0.15.0] 2022-09-11
 ### Added

--- a/share/pot/set-status.sh
+++ b/share/pot/set-status.sh
@@ -2,18 +2,18 @@
 # shellcheck disable=SC3033,SC3040,SC3043
 :
 
-: "${_POT_INTERNAL_STATUS:="starting started stopping stopped"}"
+: "${_POT_INTERNAL_STATUS:="starting doa started stopping stopped"}"
 
 set-status-help()
 {
-	cat <<-"EOH"
+	cat <<-EOH
 	Internal command, DO NOT USE IF YOU DON'T KNOW WHAT YOU ARE DOING!
 	This command is meant to be invoked using lockf
 	pot set-status [-hv] [-p pname] [-s status]
 	  -h print this help
 	  -v verbose
 	  -p pname : pot name
-	  -s status : the status [starting started stopping stopped]
+	  -s status : the status [$_POT_INTERNAL_STATUS]
 	EOH
 }
 
@@ -106,14 +106,16 @@ pot-set-status()
 				return 1
 			fi
 			;;
-		"started")
+		"started" | "doa")
 			if [ "$_current_status" != "starting" ]; then
 				return 1
 			fi
 			;;
 		"stopping")
 			# you can always stop a stopped pot (for cleanup reasons)
-			if [ "$_current_status" != "started" ] && [ "$_current_status" != "stopped" ]; then
+			if [ "$_current_status" != "started" ] &&
+			   [ "$_current_status" != "doa" ] &&
+			   [ "$_current_status" != "stopped" ]; then
 				return 1
 			fi
 			;;

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -30,6 +30,8 @@ start-cleanup()
 	if [ -z "$_pname" ]; then
 		return
 	fi
+	# doa state will only be set if pot is in state "starting"
+	lockf "${POT_TMP:-/tmp}/pot-lock-$_pname" "${_POT_PATHNAME}" set-status -p "$_pname" -s doa
 	if [ -n "$_iface" ] && _is_valid_netif "$_iface" ; then
 		pot-cmd stop -p "$_pname" -i "$_iface" -s
 	else


### PR DESCRIPTION
This introduces a distinct state called "doa" (dead on arrival), which is also an allowed prerequisite
for going to state stopping.