### PR TITLE
Destroy epair interface if stop isn't called from start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- stop: Destroy epair interface if stop is not called from start (#229)
+
 ## [0.15.2] 2022-09-17
 ### Fixed
 - start: fix pot getting stuck in state "starting" on pot start failure (#227)

--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -41,7 +41,7 @@ _js_stop()
 	_pdir="${POT_FS_ROOT}/jails/$_pname"
 	_network_type=$( _get_pot_network_type "$_pname" )
 	if _is_pot_running "$_pname" ; then
-		if _is_pot_vnet "$_pname" && [ -z "$_epair" ] && [ "$_from_start" = "YES" ]; then
+		if _is_pot_vnet "$_pname" && [ -z "$_epair" ]; then
 			_epair=$(jexec "$_pname" ifconfig | grep ^epair | cut -d':' -f1)
 			_epair="${_epair%b}a"
 		fi


### PR DESCRIPTION
This requires some thought, since I assume the original check was in there for a reason.

Fixes #229