### PR TITLE
Use unique epaira interface names

### DIFF
--- a/share/pot/set-status.sh
+++ b/share/pot/set-status.sh
@@ -12,7 +12,7 @@ set-status-help()
 	pot set-status [-hv] [-p pname] [-s status]
 	  -h print this help
 	  -v verbose
-	  -i interface : network interface (epaira)
+	  -i interface(s) : network interface (epaira)
 	  -p pname : pot name
 	  -s status : the status [$_POT_INTERNAL_STATUS]
 	EOH
@@ -53,9 +53,9 @@ _set_status()
 
 pot-set-status()
 {
-	local _pname _new_status _tmp _current_status _current_ifname _conf
-	local _ifname
-	_ifname=""
+	local _pname _new_status _tmp _current_status _current_ifnames _conf
+	local _ifnames
+	_ifnames=""
 	_pname=""
 	_new_status=""
 	OPTIND=1
@@ -72,7 +72,7 @@ pot-set-status()
 			_pname="$OPTARG"
 			;;
 		i)
-			_ifname="$OPTARG"
+			_ifnames="$OPTARG"
 			;;
 		s)
 			# shellcheck disable=SC2086
@@ -100,7 +100,7 @@ pot-set-status()
 
 	_tmp=$(_get_status "$_pname")
 	_current_status=$(echo "$_tmp" | cut -d, -f1)
-	_current_ifname=$(echo "$_tmp" | cut -d, -f2)
+	_current_ifnames=$(echo "$_tmp" | cut -d, -f2)
 	# if current status is equal to new status, it means that some other pot command is
 	# taking care of the execution of the transition and an exit code 2 is returned
 	if [ "$_current_status" = "$_new_status" ]; then
@@ -113,7 +113,7 @@ pot-set-status()
 			if [ -n "$_current_status" ] && [ "$_current_status" != "stopped" ]; then
 				return 1
 			fi
-			_ifname=""
+			_ifnames=""
 			;;
 		"started" | "doa")
 			if [ "$_current_status" != "starting" ]; then
@@ -127,15 +127,15 @@ pot-set-status()
 			   [ "$_current_status" != "stopped" ]; then
 				return 1
 			fi
-			_ifname="$_current_ifname"
-			echo "$_ifname"
+			_ifnames="$_current_ifnames"
+			echo "$_ifnames"
 			;;
 		"stopped")
 			if [ "$_current_status" != "stopping" ]; then
 				return 1
 			fi
-			_ifname=""
+			_ifnames=""
 			;;
 	esac
-	_set_status "$_pname" "$_new_status,$_ifname"
+	_set_status "$_pname" "$_new_status,$_ifnames"
 }

--- a/share/pot/set-status.sh
+++ b/share/pot/set-status.sh
@@ -12,6 +12,7 @@ set-status-help()
 	pot set-status [-hv] [-p pname] [-s status]
 	  -h print this help
 	  -v verbose
+	  -i interface : network interface (epaira)
 	  -p pname : pot name
 	  -s status : the status [$_POT_INTERNAL_STATUS]
 	EOH
@@ -52,11 +53,13 @@ _set_status()
 
 pot-set-status()
 {
-	local _pname _new_status _current_status _conf
+	local _pname _new_status _tmp _current_status _current_ifname _conf
+	local _ifname
+	_ifname=""
 	_pname=""
 	_new_status=""
 	OPTIND=1
-	while getopts "hvp:s:" _o ; do
+	while getopts "hvp:i:s:" _o ; do
 		case "$_o" in
 		h)
 			set-status-help
@@ -67,6 +70,9 @@ pot-set-status()
 			;;
 		p)
 			_pname="$OPTARG"
+			;;
+		i)
+			_ifname="$OPTARG"
 			;;
 		s)
 			# shellcheck disable=SC2086
@@ -92,7 +98,9 @@ pot-set-status()
 		return 1
 	fi
 
-	_current_status=$(_get_status "$_pname")
+	_tmp=$(_get_status "$_pname")
+	_current_status=$(echo "$_tmp" | cut -d, -f1)
+	_current_ifname=$(echo "$_tmp" | cut -d, -f2)
 	# if current status is equal to new status, it means that some other pot command is
 	# taking care of the execution of the transition and an exit code 2 is returned
 	if [ "$_current_status" = "$_new_status" ]; then
@@ -105,6 +113,7 @@ pot-set-status()
 			if [ -n "$_current_status" ] && [ "$_current_status" != "stopped" ]; then
 				return 1
 			fi
+			_ifname=""
 			;;
 		"started" | "doa")
 			if [ "$_current_status" != "starting" ]; then
@@ -113,17 +122,20 @@ pot-set-status()
 			;;
 		"stopping")
 			# you can always stop a stopped pot (for cleanup reasons)
-			if [ "$_current_status" != "started" ] &&
+			if [ "$_current_status" != "started" ] && \
 			   [ "$_current_status" != "doa" ] &&
 			   [ "$_current_status" != "stopped" ]; then
 				return 1
 			fi
+			_ifname="$_current_ifname"
+			echo "$_ifname"
 			;;
 		"stopped")
 			if [ "$_current_status" != "stopping" ]; then
 				return 1
 			fi
+			_ifname=""
 			;;
 	esac
-	_set_status "$_pname" "$_new_status"
+	_set_status "$_pname" "$_new_status,$_ifname"
 }

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -138,7 +138,8 @@ _js_etc_hosts()
 }
 
 # returns interface names of epaira and epairb
-# optional prefix, one char
+# $1 pot name
+# $2 prefix (optional)
 _js_create_epair()
 {
 	local _epaira _epaira_renamed _epairb _prefix
@@ -149,7 +150,7 @@ _js_create_epair()
 	if [ -z "${_epaira}" ]; then
 		_error "ifconfig epair failed" >&2
 		start-cleanup "$_pname"
-		exit 1 # false
+		${EXIT} 1 # false
 	fi
 
 	_epairb="${_epaira%a}b"
@@ -159,7 +160,7 @@ _js_create_epair()
 	if [ -z "${_epaira_renamed}" ]; then
 		_error "ifconfig epair rename failed" >&2
 		start-cleanup "$_pname" "$_epaira"
-		exit 1 # false
+		${EXIT} 1 # false
 	fi
 
 	echo "$_epaira_renamed"
@@ -555,7 +556,7 @@ _js_start()
 		_param="$_param vnet"
 		_stack="$( _get_pot_network_stack "$_pname" )"
 		if [ "$_stack" = "dual" ] || [ "$_stack" = "ipv4" ]; then
-			_tmp="$( _js_create_epair '4' )" || return 1
+			_tmp="$( _js_create_epair "$_pname" '4' )" || return 1
 			# shellcheck disable=SC2086
 			set -- $_tmp
 
@@ -566,7 +567,7 @@ _js_start()
 			_js_export_ports "$_pname"
 		fi
 		if [ "$_stack" = "dual" ] || [ "$_stack" = "ipv6" ]; then
-			_tmp="$( _js_create_epair '6' )" || return 1
+			_tmp="$( _js_create_epair "$_pname" '6' )" || return 1
 			# shellcheck disable=SC2086
 			set -- $_tmp
 
@@ -578,7 +579,7 @@ _js_start()
 		fi
 		;;
 	"private-bridge")
-		_tmp="$( _js_create_epair '4' )" || return 1
+		_tmp="$( _js_create_epair "$_pname" '4' )" || return 1
 		# shellcheck disable=SC2086
 		set -- $_tmp
 

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -24,16 +24,16 @@ start-help()
 # $2 the network interface, if created
 start-cleanup()
 {
-	local _pname _iface
+	local _pname _epaira
 	_pname=$1
-	_iface=${2}a
+	_epaira=$2
 	if [ -z "$_pname" ]; then
 		return
 	fi
 	# doa state will only be set if pot is in state "starting"
 	lockf "${POT_TMP:-/tmp}/pot-lock-$_pname" "${_POT_PATHNAME}" set-status -p "$_pname" -s doa
-	if [ -n "$_iface" ] && _is_valid_netif "$_iface" ; then
-		pot-cmd stop -p "$_pname" -i "$_iface" -s
+	if [ -n "$_epaira" ] && _is_valid_netif "$_epaira" ; then
+		pot-cmd stop -p "$_pname" -i "$_epaira" -s
 	else
 		pot-cmd stop -p "$_pname" -s
 	fi
@@ -126,34 +126,50 @@ _js_etc_hosts()
 	grep '^pot.hosts=' "$_cfile" | sed 's/^pot.hosts=//g' >> "$_phosts"
 }
 
+# returns interface names of epaira and epairb
+# optional name prefix
 _js_create_epair()
 {
-	local _epair
-	_epair=$(ifconfig epair create descr "$_pname" group "pot")
+	local _epaira _epairb _prefix
 
-	if [ -z "${_epair}" ]; then
+	_prefix=$1
+	_epaira=$(ifconfig epair create descr "$_pname" group "pot")
+
+	if [ -z "${_epaira}" ]; then
 		_error "ifconfig epair failed"
 		start-cleanup "$_pname"
 		exit 1 # false
 	fi
-	echo "${_epair%a}"
+
+	_epairb="${_epaira%a}b"
+	_epaira=$(ifconfig "$_epaira" name \
+	    "$(printf "p%s%x%x" "$_prefix" "$(date +%s)" "$$")")
+	if [ -z "${_epaira}" ]; then
+		_error "ifconfig epair rename failed"
+		start-cleanup "$_pname"
+		exit 1 # false
+	fi
+
+	echo "$_epaira"
+	echo "$_epairb"
 }
 
 # $1 pot name
-# $2 epair interface
+# $2 epaira interface
+# $3 epairb interface
 _js_vnet()
 {
-	local _pname _bridge _epair _epairb _ip
+	local _pname _bridge _epaira _epairb _ip
 	_pname=$1
 	if ! _is_vnet_ipv4_up ; then
 		_info "Internal network not found! Calling vnet-start to fix the issue"
 		pot-cmd vnet-start
 	fi
 	_bridge=$(_pot_bridge_ipv4)
-	_epair=${2}a
-	_epairb="${2}b"
-	ifconfig "${_epair}" up
-	ifconfig "$_bridge" addm "${_epair}"
+	_epaira=$2
+	_epairb=$3
+	ifconfig "$_epaira" up
+	ifconfig "$_bridge" addm "$_epaira"
 	_ip=$( _get_ip_var "$_pname" )
 	## if norcscript - write a ad-hoc one
 	if [ "$(_get_conf_var "$_pname" "pot.attr.no-rc-script")" = "YES" ]; then
@@ -179,20 +195,21 @@ _js_vnet()
 }
 
 # $1 pot name
-# $2 epair interface
+# $2 epaira interface
+# $3 epairb interface
 _js_vnet_ipv6()
 {
-	local _pname _bridge _epair _epairb _ip
+	local _pname _bridge _epaira _epairb _ip
 	_pname=$1
 	if ! _is_vnet_ipv6_up ; then
 		_info "Internal network not found! Calling vnet-start to fix the issue"
 		pot-cmd vnet-start
 	fi
 	_bridge=$(_pot_bridge_ipv6)
-	_epair=${2}a
-	_epairb="${2}b"
-	ifconfig "${_epair}" up
-	ifconfig "$_bridge" addm "${_epair}"
+	_epaira=$2
+	_epairb=$3
+	ifconfig "$_epaira" up
+	ifconfig "$_bridge" addm "$_epaira"
 	if [ "$(_get_conf_var "$_pname" "pot.attr.no-rc-script")" = "YES" ]; then
 		cat >>"${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc" <<-EOT
 		if ! ifconfig ${_epairb} >/dev/null 2>&1; then
@@ -218,10 +235,11 @@ _js_vnet_ipv6()
 }
 
 # $1 pot name
-# $2 epair interface
+# $2 epaira interface
+# $3 epairb interface
 _js_private_vnet()
 {
-	local _pname _bridge_name _bridge _epair _epairb _ip _net_size _gateway
+	local _pname _bridge_name _bridge _epaira _epairb _ip _net_size _gateway
 	_pname=$1
 	_bridge_name="$( _get_conf_var "$_pname" bridge )"
 	if ! _is_vnet_ipv4_up "$_bridge_name" ; then
@@ -229,10 +247,10 @@ _js_private_vnet()
 		pot-cmd vnet-start -B "$_bridge_name"
 	fi
 	_bridge="$(_private_bridge "$_bridge_name")"
-	_epair=${2}a
-	_epairb="${2}b"
-	ifconfig "${_epair}" up
-	ifconfig "$_bridge" addm "${_epair}"
+	_epaira=$2
+	_epairb=$3
+	ifconfig "$_epaira" up
+	ifconfig "$_bridge" addm "$_epaira"
 	_ip=$( _get_ip_var "$_pname"  )
 	_net_size="$(_get_bridge_var "$_bridge_name" net)"
 	_net_size="${_net_size##*/}"
@@ -415,11 +433,13 @@ _js_env()
 # $1 jail name
 _js_start()
 {
-	local _pname _confdir _iface _hostname _osrelease _param _ip _cmd _persist
+	local _pname _confdir _epaira _epairb
+	local _hostname _osrelease _param _ip _cmd _persist
 	local _stack _value _name _type _wait_pid _exit_code
 	_pname="$1"
 	_confdir="${POT_FS_ROOT}/jails/$_pname/conf"
-	_iface=
+	_epaira=
+	_epairb=
 	_param="allow.set_hostname=false allow.raw_sockets allow.socket_af allow.sysvipc"
 	_param="$_param allow.chflags exec.clean mount.devfs"
 	_param="$_param sysvmsg=new sysvsem=new sysvshm=new"
@@ -524,21 +544,34 @@ _js_start()
 		_param="$_param vnet"
 		_stack="$( _get_pot_network_stack "$_pname" )"
 		if [ "$_stack" = "dual" ] || [ "$_stack" = "ipv4" ]; then
-			_iface="$( _js_create_epair )"
-			_js_vnet "$_pname" "$_iface"
-			_param="$_param vnet.interface=${_iface}b"
+			# shellcheck disable=SC2046
+			set -- $( _js_create_epair "4" )
+
+			_epaira=$1
+			_epairb=$2
+			_js_vnet "$_pname" "$_epaira" "$_epairb"
+			_param="$_param vnet.interface=${_epairb}"
 			_js_export_ports "$_pname"
 		fi
 		if [ "$_stack" = "dual" ] || [ "$_stack" = "ipv6" ]; then
-			_iface="$( _js_create_epair )"
-			_js_vnet_ipv6 "$_pname" "$_iface"
-			_param="$_param vnet.interface=${_iface}b"
+			# XXX: dual doesn't work correctly (extra interfaces!)
+			# shellcheck disable=SC2046
+			set -- $( _js_create_epair "6")
+
+			_epaira=$1
+			_epairb=$2
+			_js_vnet_ipv6 "$_pname" "$_epaira" "$_epairb"
+			_param="$_param vnet.interface=${_epairb}"
 		fi
 		;;
 	"private-bridge")
-		_iface="$( _js_create_epair )"
-		_js_private_vnet "$_pname" "$_iface"
-		_param="$_param vnet vnet.interface=${_iface}b"
+		# shellcheck disable=SC2046
+		set -- $( _js_create_epair "4" )
+
+		_epaira=$1
+		_epairb=$2
+		_js_private_vnet "$_pname" "$_epaira" "$_epairb"
+		_param="$_param vnet vnet.interface=${_epairb}"
 		_js_export_ports "$_pname"
 		;;
 	esac
@@ -595,7 +628,8 @@ _js_start()
 		echo "$_wait_pid" >"${POT_TMP:-/tmp}/pot_main_pid_${_pname}"
 	fi
 	# Here is where the pot is marked as started
-	lockf "${POT_TMP:-/tmp}/pot-lock-$_pname" "${_POT_PATHNAME}" set-status -p "$_pname" -s started
+	lockf "${POT_TMP:-/tmp}/pot-lock-$_pname" "${_POT_PATHNAME}" set-status \
+	  -p "$_pname" -s started -i "$_epaira"
 	rc=$?
 	if [ $rc -eq 2 ]; then
 		_info "pot $_pname is already started (???)"
@@ -625,7 +659,7 @@ _js_start()
 			# returning, but the situation is quite messed up
 			return 1
 		fi
-		start-cleanup "$_pname" "${_iface}"
+		start-cleanup "$_pname" "${_epaira}"
 		if [ "$_exit_code" -ne 0 ]; then
 			# return code to signal application exit error
 			return 125
@@ -644,7 +678,7 @@ _js_start()
 			# returning, but the situation is quite messed up
 			return 1
 		fi
-		start-cleanup "$_pname" "${_iface}"
+		start-cleanup "$_pname" "${_epaira}"
 		return 1
 	fi
 }

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -142,9 +142,10 @@ _js_etc_hosts()
 # $2 prefix (optional)
 _js_create_epair()
 {
-	local _epaira _epaira_renamed _epairb _prefix
+	local _epaira _epaira_renamed _epairb _pname _prefix
 
-	_prefix="$1"
+	_pname="$1"
+	_prefix="$2"
 	_epaira=$(ifconfig epair create descr "$_pname" group "pot")
 
 	if [ -z "${_epaira}" ]; then

--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -8,7 +8,7 @@ stop-help()
 	pot stop [-hv] -p potname | potname
 	  -h print this help
 	  -v verbose
-	  -i interface : network interface (epaira) (INTERNAL USE ONLY)
+	  -i interface(s) : network interface (epaira) (INTERNAL USE ONLY)
 	  -s called from start (INTERNAL USE ONLY)
 	  -p potname : the pot to be stopped
 	     the -p can be omitted and the last argument will be interpreted
@@ -35,11 +35,10 @@ _js_cpu_rebalance()
 # $1 pot name
 _js_stop()
 {
-	local _pname _pdir _epaira _ip _aname _from_start
+	local _pname _pdir _epaira _epaira_ifs _ip _aname _from_start
 	_pname="$1"
 	_from_start="$2"
-	_epaira="$3"
-
+	_epaira_ifs="$3"
 	_pdir="${POT_FS_ROOT}/jails/$_pname"
 	_network_type=$( _get_pot_network_type "$_pname" )
 	if _is_pot_running "$_pname" ; then
@@ -55,13 +54,15 @@ _js_stop()
 		jail -q -r "$_pname"
 	fi
 	# those are clean up operations for a pot already stopped
-	if [ -n "$_epaira" ]; then
-		_debug "Remove ${_epaira} network interface (and its b-side)"
-		sleep 1 # try to avoid a race condition in the epair driver,
+	if [ -n "$_epaira_ifs" ]; then
+		for _epaira in $(echo "$_epaira_ifs" | tr : ' '); do
+			_debug "Remove ${_epaira} epair network interfaces"
+			sleep 1 # try to avoid a race condition in the epair driver,
 				# potentially causing a kernel panic, which should
 				# be fixed in FreeBSD 13.1:
 				# https://cgit.freebsd.org/src/commit/?h=stable/13&id=f4aba8c9f0c
-		ifconfig "${_epaira}" destroy
+			ifconfig "${_epaira}" destroy
+		done
 	elif [ "$_network_type" = "alias" ]; then
 		_ip=$( _get_ip_var "$_pname" )
 		_debug "Remove $_ip aliases"
@@ -145,24 +146,11 @@ _js_rm_resolv()
 	fi
 }
 
-_epair_cleanup()
-{
-	local _epairs_a _epairs_b
-	_epairs_b="$(ifconfig | grep '^epair[0-9][0-9]*b' | sed 's/:.*$//' | sort)"
-	_epairs_a="$(ifconfig | grep '^epair[0-9][0-9]*a' | sed 's/:.*$//' | sort)"
-	for _e in $_epairs_b ; do
-		# shellcheck disable=SC2086
-		if _is_in_list "${_e%b}a" $_epairs_a ; then
-			ifconfig "$_e" destroy
-		fi
-	done
-}
-
 pot-stop()
 {
-	local _pname _ifname _from_start
+	local _pname _ifnames _from_start
 	_pname=
-	_ifname=
+	_ifnames=
 	_from_start="NO"
 
 	OPTIND=1
@@ -179,7 +167,7 @@ pot-stop()
 			_pname="$OPTARG"
 			;;
 		i)
-			_ifname="$OPTARG"
+			_ifnames="$OPTARG"
 			;;
 		s)
 			_from_start="YES"
@@ -207,14 +195,14 @@ pot-stop()
 	fi
 
 	# Here is where the pot is stopping
-	_epaira="$(lockf "${POT_TMP:-/tmp}/pot-lock-$_pname" \
+	_epaira_ifs="$(lockf "${POT_TMP:-/tmp}/pot-lock-$_pname" \
 	  "${_POT_PATHNAME}" set-status -p "$_pname" -s stopping)"
 	rc=$?
 	if [ $rc -eq 2 ]; then
 		if [ $_from_start = "YES" ]; then
 			_debug "pot $_pname is already stopping, but we are cleaning up from start-cleanup"
 		else
-			_error "pot $_pname is arleady stopping!"
+			_error "pot $_pname is already stopping!"
 			${EXIT} 1
 		fi
 	fi
@@ -222,11 +210,11 @@ pot-stop()
 		_error "pot $_pname is not in a state where it can be stopped"
 		${EXIT} 1
 	fi
-	if [ -z "$_ifname" ]; then
-		_ifname="$_epaira"
+	if [ -z "$_ifnames" ]; then
+		_ifnames="$_epaira_ifs"
 	fi
 
-	if ! _js_stop "$_pname" "$_from_start" "$_ifname"; then
+	if ! _js_stop "$_pname" "$_from_start" "$_ifnames"; then
 		_error "Stop the pot $_pname failed"
 		${EXIT} 1
 	fi
@@ -235,14 +223,11 @@ pot-stop()
 	lockf "${POT_TMP:-/tmp}/pot-lock-$_pname" "${_POT_PATHNAME}" set-status -p "$_pname" -s stopped
 	rc=$?
 	if [ $rc -eq 2 ]; then
-		_error "pot $_pname is arleady stopped!"
+		_error "pot $_pname is already stopped!"
 		${EXIT} 1
 	fi
 	if [ $rc -eq 1 ]; then
 		_error "pot $_pname is not in a state where it can marked as stopped"
 		${EXIT} 1
 	fi
-	# Currently, epair clean up could remove interfaces created to start another pot
-	# it shouldn't be needed if after a start there is alwasy a stop
-	#_epair_cleanup
 }


### PR DESCRIPTION
This changes the code to rename the epaira side of interfaces to a unique value and stores it in the status file.

This has multiple advantages:
- Removing the wrong interface highly unlikely
- No need to poke into the running (or potentially dying) pot when stopping

Note that dual stack isn't covered yet (wasn't with the previous either).