### PR TITLE
Fix flavor exec script and other small bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- flavours: scripts are made executable when loading
+- destroy: remove status file when destroying
+
 ### Fixed
 - Reverted the change of permissions of pot root mountpoint to fix a regression (#233)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Reverted the change of permissions of pot root mountpoint to fix a regression (#233)
+- set-attr: fix no-etc-hosts attribute handling
 
 ## [0.15.3] 2022-09-17
 ### Fixed

--- a/share/pot/common-flv.sh
+++ b/share/pot/common-flv.sh
@@ -17,13 +17,13 @@ _get_flavour_script()
 {
 	local _flv_name
 	_flv_name="$1"
-	if [ -f "$_flv_name" ] && [ -x "$_flv_name" ] && [ "$_flv_name" != "${_flv_name%%.sh}" ]; then ## it's a script path name
+	if [ -f "$_flv_name" ] && [ "$_flv_name" != "${_flv_name%%.sh}" ]; then ## it's a script path name
 		echo "$_flv_name"
-	elif [ -f "$_flv_name.sh" ] && [ -x "$_flv_name.sh" ];  then ## it's a path name
+	elif [ -f "$_flv_name.sh" ];  then ## it's a path name
 		echo "$_flv_name.sh"
-	elif [ -f "./$_flv_name.sh" ] && [ -x "./$_flv_name.sh" ]; then
+	elif [ -f "./$_flv_name.sh" ]; then
 		echo "./$_flv_name.sh"
-	elif [ -f "${_POT_FLAVOUR_DIR}/$_flv_name.sh" ] || [ -x "${_POT_FLAVOUR_DIR}/$_flv_name.sh" ]; then
+	elif [ -f "${_POT_FLAVOUR_DIR}/$_flv_name.sh" ]; then
 		echo "${_POT_FLAVOUR_DIR}/$_flv_name.sh"
 	fi
 }
@@ -129,6 +129,7 @@ _exec_flv()
 		_debug "Starting $_pname pot for the initial bootstrap"
 		pot-cmd start "$_pname"
 		cp -v "${_flv_script}" "$_pdir/m/tmp"
+		chmod a+x "$_pdir/m/tmp/$(basename "${_flv_script}" )"
 		_debug "Executing $_flv script on $_pname"
 		if ! jexec "$_pname" "/tmp/$(basename "${_flv_script}")" "$_pname" ; then
 			_error "create: flavour $_flv failed (script)"

--- a/share/pot/destroy.sh
+++ b/share/pot/destroy.sh
@@ -309,4 +309,7 @@ pot-destroy()
 			${EXIT} 1
 		fi
 	fi
+	if [ -f "${POT_TMP:-/tmp}/pot_status_${_pname}" ]; then
+		rm -f "${POT_TMP:-/tmp}/pot_status_${_pname}"
+	fi
 }

--- a/share/pot/set-attribute.sh
+++ b/share/pot/set-attribute.sh
@@ -144,6 +144,7 @@ pot-set-attribute()
 		"early-start-at-boot"|\
 		"persistent"|\
 		"no-rc-script"|\
+		"no-etc-hosts"|\
 		"prunable"|\
 		"localhost-tunnel")
 			_cmd=_set_boolean_attribute

--- a/share/pot/show.sh
+++ b/share/pot/show.sh
@@ -75,7 +75,7 @@ _show_pot_run()
 	_ip="$( _get_ip_var "$_pname" )"
 	if [ "$_network_type" = "public-bridge" ]; then
 		_aname="$( _get_pot_rdr_anchor_name "$_pname")"
-		if pfctl -a "pot-rdr" -s Anchors | grep -q "pot-rdr/${_aname}$" ; then
+		if pfctl -a "pot-rdr" -s Anchors 2>/dev/null | grep -q "pot-rdr/${_aname}$" ; then
 			printf "\\n\\tNetwork port redirection\\n"
 			pfctl -a "pot-rdr/$_aname" -s nat -P | grep -F \ "${_ip}"\  | sed 's/rdr pass on .* inet proto tcp from any to //g' | sed 's/ =//g' | while read -r rule ; do
 				printf "\\t\\t%s\\n" "$rule"


### PR DESCRIPTION
Fixing PRs

Set of fixes for small bugs that I've found.
flavor: when the script is not executable, it's ignored and not executed
destroy: remove also status file
set-attr: no-etc-hosts is not recognized
show: removed an error message generated by pfctl