### PR TITLE
Github CI action, fix pot destroy leftovers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: Run CI
+on:
+  workflow_dispatch:
+  push:
+    branches: [ github-ci-action ]
+#  pull_request:
+#    branches: [ master ]
+
+jobs:
+  ci_test_suite:
+    name: CI test suite
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { os: macos-12 }
+        release: [ "13.1" ]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests/CI/run.sh
+      uses: vmactions/freebsd-vm@v0
+      with:
+        mem: 8192
+        usesh: true
+        copyback: false
+        prepare: pkg install -y curl gmake potnet freebsd-release-manifests nmap
+        run: |
+          #####################################################################################
+          ###  Prepare, build, and test
+          #####################################################################################
+          ###  based on ref: <https://github.com/rust-lang/rustup/pull/2783>
+          ###  and on ref: <https://github.com/uutils/coreutils/commit/86c610a84b8b6c>
+          ###  * NOTE: All steps need to be run in this block, otherwise, we are operating back
+          ###    on the mac host
+          set -exo pipefail
+          #
+          ### Basic user setup ################################################################
+          TEST_USER=tester
+          TEST_USER_HOME="/opt/$TEST_USER"
+          REPO_NAME=${GITHUB_WORKSPACE##*/}
+          WORKSPACE_PARENT="/Users/runner/work/${REPO_NAME}"
+          WORKSPACE="${WORKSPACE_PARENT}/${REPO_NAME}"
+          OS_VERSION="$(freebsd-version | awk -F- '{print $1}')"
+          PUB_INTF="$(netstat -4rn | grep default | awk '{ print $4}')"
+          ifconfig
+          #
+          mkdir -p "$TEST_USER_HOME"
+          pw adduser -n "$TEST_USER" -d "$TEST_USER_HOME" -c "Tester" -h -
+          chown -R "$TEST_USER":"$TEST_USER" "$TEST_USER_HOME"
+          chown -R "$TEST_USER":"$TEST_USER" "/$WORKSPACE_PARENT"/
+          whoami
+          #
+          ### Output some information about the environment  ##################################
+          # environment
+          echo "## environment"
+          env | sort
+          # tooling info
+          echo "## installed packages"
+          pkg info
+          #
+          ### Create zpool ####################################################################
+          dd if=/dev/zero of=/zfs1 bs=1 count=1 seek=2G
+          zdev=$(mdconfig -a -t vnode -S 4096 -f /zfs1)
+          zpool create -f zroot "$zdev"
+          #
+          ### Configure pf and pot ############################################################
+          echo "set skip on lo0" >/etc/pf.conf
+          echo pass >>/etc/pf.conf
+          service pf enable
+          service pf start
+          bin/pot init
+          #
+          ### Run CI tests ################################################
+          cd "$WORKSPACE"
+          cp -f etc/pot/pot.default.conf etc/pot/pot.conf
+          cd tests/CI
+          set +e
+          FAULT=0
+          ./run.sh || FAULT=1
+          echo "Log output:"
+          cat pot-ci-*
+          if [ $FAULT -ne 0 ]; then exit 1; fi
+          #
+          ### Finished ########################################################################
+          echo "Done"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Reverted the change of permissions of pot root mountpoint to fix a regression (#233)
 - set-attr: fix no-etc-hosts attribute handling
+- Remove leftover mount points on destroy (#236)
 
 ## [0.15.3] 2022-09-17
 ### Fixed

--- a/share/pot/destroy.sh
+++ b/share/pot/destroy.sh
@@ -41,9 +41,9 @@ _pot_zfs_destroy()
 	_jdset=${POT_ZFS_ROOT}/jails/$_pname
 	if ! _zfs_dataset_valid "$_jdset" ; then
 		## if a directory is found, just remove if
-		if [ -d "${_POT_FS_ROOT}/jails/$_pname" ]; then
+		if [ -d "${POT_FS_ROOT}/jails/$_pname" ]; then
 			_debug "Dataset of $_pname not found, but removing the directory anyway"
-			rm -rf "${_POT_FS_ROOT}/jails/$_pname"
+			rm -rf "${POT_FS_ROOT}/jails/$_pname"
 			return 0 # true
 		fi
 		_error "$_pname not found"
@@ -61,6 +61,10 @@ _pot_zfs_destroy()
 		_error "zfs failed to destroy the dataset $_jdset"
 		return 1 # false
 	fi
+	if [ -d "${POT_FS_ROOT}/jails/$_pname" ]; then
+		_debug "Removing leftover mountpoint ${POT_FS_ROOT}/jails/$_pname"
+		rm -rf "${POT_FS_ROOT}/jails/$_pname"
+	fi
 	rm -f "/usr/local/etc/syslog.d/${_pname}.conf" "/usr/local/etc/newsyslog.conf.d/${_pname}.conf" "/var/log/pot/${_pname}.log"
 	return $?
 }
@@ -71,8 +75,15 @@ _base_zfs_destroy()
 	local _bname _bdset
 	_bname=$1
 	_bdset=${POT_ZFS_ROOT}/bases/$_bname
-	_zfs_dataset_destroy "$_bdset"
-	return $?
+	if ! _zfs_dataset_destroy "$_bdset" ; then
+		_error "zfs failed to destroy the dataset $_bdset"
+		return 1 # false
+	fi
+	if [ -d "${POT_FS_ROOT}/bases/$_bname" ]; then
+		_debug "Removing leftover mountpoint ${POT_FS_ROOT}/bases/$_bname"
+		rm -rf "${POT_FS_ROOT}/bases/$_bname"
+	fi
+	return 0
 }
 
 # $1 base name
@@ -81,8 +92,15 @@ _fscomp_zfs_destroy()
 	local _fname _fdset
 	_fname=$1
 	_fdset=${POT_ZFS_ROOT}/fscomp/$_fname
-	_zfs_dataset_destroy "$_fdset"
-	return $?
+	if ! _zfs_dataset_destroy "$_fdset" ; then
+		_error "zfs failed to destroy the dataset $_fdset"
+		return 1 # false
+	fi
+	if [ -d "${POT_FS_ROOT}/fscomp/$_fname" ]; then
+		_debug "Removing leftover mountpoint ${POT_FS_ROOT}/fscomp/$_fname"
+		rm -rf "${POT_FS_ROOT}/fscomp/$_fname"
+	fi
+	return 0
 }
 
 pot-destroy()


### PR DESCRIPTION
Slightly improve CI script (e.g., detect IPv6 missing), add github CI action (triggers on push to the branch and should be able to be run manually once it lands in master). As running it is quite expensive, I wouldn't run it automatically at the moment. The idea is to have the CI workflow in github actions, so we can run it before cutting a release.

Pot destroy left directories behind on destroy (side-effect of the previous partially reverted commit, but could also happen in other ways, hence the explicit fix by removing those directores).
