### PR TITLE
Add pot group to protect pot root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           echo pass >>/etc/pf.conf
           service pf enable
           service pf start
+          pw groupadd pot
           bin/pot init
           #
           ### Run CI tests ################################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - flavours: scripts are made executable when loading
 - destroy: remove status file when destroying
 - vnet: use unique epaira interface names (#232)
+- Add pot group to protect pot root (#240)
 
 ### Fixed
 - Reverted the change of permissions of pot root mountpoint to fix a regression (#233)

--- a/etc/pot/pot.conf.sample
+++ b/etc/pot/pot.conf.sample
@@ -13,6 +13,9 @@
 # This is where pot is going to store temporary files
 # POT_TMP=/tmp
 
+# This is the group owning POT_FS_ROOT
+# POT_GROUP=pot
+
 # This is the suffix added to temporary files created using mktemp,
 # X is a placeholder for a random character, see mktemp(1)
 # POT_MKTEMP_SUFFIX=.XXXXXXXX

--- a/etc/pot/pot.default.conf
+++ b/etc/pot/pot.default.conf
@@ -13,6 +13,9 @@ POT_CACHE=/var/cache/pot
 # This is where pot is going to store temporary files
 POT_TMP=/tmp
 
+# This is the group owning POT_FS_ROOT
+POT_GROUP=pot
+
 # This is the suffix added to temporary files created using mktemp,
 # X is a placeholder for a random character, see mktemp(1)
 POT_MKTEMP_SUFFIX=.XXXXXXXX

--- a/share/pot/clone.sh
+++ b/share/pot/clone.sh
@@ -99,7 +99,6 @@ _cj_zfs()
 		fi
 		_debug "clone $_dset@$_snap into $_jdset/m"
 		zfs clone -o mountpoint="$_pdir/m" "$_dset@$_snap" "$_jdset/m"
-		_fix_pot_mountpoint_permissions "$_pdir/m"
 		touch "$_pdir/conf/fscomp.conf"
 		while read -r line ; do
 			_dset=$( echo "$line" | awk '{print $1}' )

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -935,22 +935,6 @@ _get_pot_snaps()
 	done
 }
 
-# $1 mountpoint to adjust permissions for
-_fix_pot_mountpoint_permissions()
-{
-	local _mp _exp_perm
-	_mp="$1"
-	_exp_perm="755"
-
-	if [ "$(stat -f "%Lp" "${_mp}")" != "$_exp_perm" ]; then
-		_debug "Setting mountpoint permission for $_mp"
-		# chomd 755 allows everyone inside the jail to access the file system
-		# permissions like 700 don't allow access to the file system to any non-user also in the jail
-		# causing issue to applications like nginx
-		chmod "$_exp_perm" "$_mp" || ${EXIT} 1
-	fi
-}
-
 # $1 mountpoint to create (proper permissions are applied)
 _create_pot_mountpoint()
 {
@@ -961,8 +945,6 @@ _create_pot_mountpoint()
 		_debug "Creating mountpoint $_mp"
 		mkdir -p "$_mp" || exit 1
 	fi
-
-	_fix_pot_mountpoint_permissions "$_mp"
 }
 
 # $1 pot name

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -168,6 +168,10 @@ _conf_check()
 		_qerror "$1" "POT_FS_ROOT is mandatory"
 		return 1 # false
 	fi
+	if ! getent group "${POT_GROUP:-pot}" >/dev/null 2>&1; then
+		_qerror "$1" "Group '${POT_GROUP:-pot}' is missing, create it or change POT_GROUP"
+		return 1 # false
+	fi
 	return 0 # true
 }
 
@@ -231,6 +235,16 @@ _zfs_exist()
 	_mnt_="$(zfs list -H -o mountpoint "$1" 2> /dev/null )"
 	if [ "$_mnt_" != "$2" ]; then
 		return 1 # false
+	fi
+	return 0 # true
+}
+
+# check if the dataset $1 is mounted
+# $1 the dataset NAME
+_zfs_mounted()
+{
+	if [ "$(zfs get -Ho value mounted "$1")" != "yes" ]; then
+		return 1; # false
 	fi
 	return 0 # true
 }
@@ -1076,8 +1090,20 @@ pot-cmd()
 	shift
 	if [ ! -r "${_POT_INCLUDE}/${_cmd}.sh" ]; then
 		_error "Fatal error! $_cmd implementation not found!"
-		exit 1
+		${EXIT} 1
 	fi
+
+	if [ "$_cmd" != "init" ]&& [ "$_cmd" != "de-init" ] ; then
+		if [ ! -d "$POT_FS_ROOT" ]; then
+			_error "$POT_FS_ROOT does not exist, please run 'pot init'"
+			${EXIT} 1
+		fi
+		if [ ! -r "$POT_FS_ROOT" ]; then
+			_error "Current user has no read access to $POT_FS_ROOT"
+			${EXIT} 1
+		fi
+	fi
+
 	# shellcheck disable=SC1090
 	. "${_POT_INCLUDE}/${_cmd}.sh"
 	_func=pot-${_cmd}

--- a/share/pot/create.sh
+++ b/share/pot/create.sh
@@ -79,8 +79,6 @@ _c_zfs_single()
 		_info "$_pdset exists already"
 	fi
 
-	_create_pot_mountpoint "$_pdir/m"
-
 	if [ -z "$_potbase" ]; then
 		# create an empty dataset
 		if ! zfs create "$_pdset/m" ; then

--- a/share/pot/import.sh
+++ b/share/pot/import.sh
@@ -107,7 +107,6 @@ _import_pot()
 		xzcat "${POT_CACHE}/$_filename" | zfs receive \
 		  $(_get_zfs_receive_extra_args) "${POT_ZFS_ROOT}/jails/$_pname"
 	fi
-	_fix_pot_mountpoint_permissions "${POT_FS_ROOT}/jails/$_pname/m"
 
 	# pot.conf modifications
 	_hostname="${_pname}.$( hostname )"

--- a/share/pot/mount-in.sh
+++ b/share/pot/mount-in.sh
@@ -64,7 +64,6 @@ _mountpoint_validation()
 	fi
 	# if the mountpoint doesn't exist, make it
 	if [ ! -d "$_mpdir/$_mnt_p" ]; then
-		_create_pot_mountpoint "$_mpdir"
 		if ! mkdir -p "$_mpdir/$_mnt_p" ; then
 			if eval $_mounted ; then
 				_pot_umount "$_pname" >/dev/null

--- a/share/pot/rename.sh
+++ b/share/pot/rename.sh
@@ -67,7 +67,6 @@ _rn_zfs()
 		zfs rename "$_dset" "$_nset"
 
 	#sudo zfs mount zroot/pot/jails/dns2
-		_create_pot_mountpoint "${POT_FS_ROOT}/jails/$_newname/m"
 		_debug "Mount $_nset"
 		zfs mount "$_nset"
 	#sudo zfs mount zroot/pot/jails/dns2/custom
@@ -88,7 +87,6 @@ _rn_zfs()
 		fi
 		_debug "Renaming $_dset in $_nset"
 		zfs rename "$_dset" "$_nset"
-		_create_pot_mountpoint "${POT_FS_ROOT}/jails/$_newname/m"
 		_debug "Mount $_nset"
 		zfs mount "$_nset"
 		if _zfs_dataset_valid "$_nset/m" ; then

--- a/tests/clone2.sh
+++ b/tests/clone2.sh
@@ -26,12 +26,6 @@ date()
 	fi
 }
 
-stat()
-{
-	__monitor STAT "$@"
-	echo 700
-}
-
 . pipefail-stub.sh
 
 # UUT
@@ -97,10 +91,6 @@ test_cj_zfs_001()
 	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG3
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@4321" ZFS_CALL3_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG5
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_002()
@@ -117,10 +107,6 @@ test_cj_zfs_002()
 	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL2_ARG3
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-2/custom@4321" ZFS_CALL2_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL2_ARG5
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_003()
@@ -140,10 +126,6 @@ test_cj_zfs_003()
 	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG3
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@4321" ZFS_CALL3_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG5
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_004()
@@ -160,10 +142,6 @@ test_cj_zfs_004()
 	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL2_ARG3
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-2/custom@4321" ZFS_CALL2_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL2_ARG5
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_005()
@@ -188,10 +166,6 @@ test_cj_zfs_005()
 	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/custom" ZFS_CALL5_ARG3
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-nosnap/custom@55555" ZFS_CALL5_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL5_ARG5
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_020()
@@ -202,10 +176,6 @@ test_cj_zfs_020()
 	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
 	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
 	assertEqualsMon "undo_clone calls" "1" UNDO_CLONE_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_040()
@@ -221,10 +191,6 @@ test_cj_zfs_040()
 	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG3
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single/m@6688" ZFS_CALL2_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG5
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_041()
@@ -240,10 +206,6 @@ test_cj_zfs_041()
 	assertEqualsMon "zfs arg3" "mountpoint=${POT_FS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG3
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single-run/m@6688" ZFS_CALL2_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG5
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_060()
@@ -260,10 +222,6 @@ test_cj_zfs_060()
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot-single/m@12345678" ZFS_CALL2_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG5
 	assertEqualsMon "zfs last snap calls" "0" ZFSLASTSNAP_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_061()
@@ -284,10 +242,6 @@ test_cj_zfs_061()
 	assertEqualsMon "zfs arg4" "${POT_ZFS_ROOT}/jails/test-pot/custom@12345678" ZFS_CALL3_ARG4
 	assertEqualsMon "zfs arg5" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL3_ARG5
 	assertEqualsMon "zfs last snap calls" "0" ZFSLASTSNAP_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 setUp()

--- a/tests/common4.sh
+++ b/tests/common4.sh
@@ -67,6 +67,7 @@ setUp()
 	__mon_init
 	POT_ZFS_ROOT=zpot
 	POT_FS_ROOT=/opt
+	POT_GROUP="$(id -ng)"
 }
 
 tearDown()

--- a/tests/create2.sh
+++ b/tests/create2.sh
@@ -23,22 +23,10 @@ chmod()
 	if [ "$2" = "/tmp/jails/new-pot/m/tmp" ]; then
 		return 0 # true
 	fi
-	if [ "$2" = "/tmp/jails/new-pot/m" ]; then
-		return 0 # true
-	fi
 	if [ "$2" = "/tmp/jails/test-pot/m/tmp" ]; then
 		return 0 # true
 	fi
-	if [ "$2" = "/tmp/jails/test-pot/m" ]; then
-		return 0 # true
-	fi
 	/bin/chmod $@
-}
-
-stat()
-{
-	__monitor STAT "$@"
-	echo 755
 }
 
 . pipefail-stub.sh
@@ -91,10 +79,6 @@ test_cj_zfs_001()
 	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
 	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
 	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_002()
@@ -129,10 +113,6 @@ test_cj_zfs_002()
 	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
 	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
 	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_003()
@@ -167,10 +147,6 @@ test_cj_zfs_003()
 	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
 	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
 	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_004()
@@ -194,10 +170,6 @@ test_cj_zfs_004()
 	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
 	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
 	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_021()
@@ -209,10 +181,6 @@ test_cj_zfs_021()
 	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" MKDIR_CALL1_ARG2
 	assertEqualsMon "info calls" "1" INFO_CALLS
 	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/test-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_022()
@@ -224,10 +192,6 @@ test_cj_zfs_022()
 	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" MKDIR_CALL1_ARG2
 	assertEqualsMon "info calls" "3" INFO_CALLS
 	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/test-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_023()
@@ -239,10 +203,6 @@ test_cj_zfs_023()
 	assertEqualsMon "mkdir arg2" "${POT_FS_ROOT}/jails/test-pot/m" MKDIR_CALL1_ARG2
 	assertEqualsMon "info calls" "2" INFO_CALLS
 	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/test-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_041()
@@ -254,17 +214,12 @@ test_cj_zfs_041()
 	assertEqualsMon "zfs c1 arg2" "${POT_ZFS_ROOT}/jails/new-pot" ZFS_CALL1_ARG2
 	assertEqualsMon "zfs c2 arg1" "create" ZFS_CALL2_ARG1
 	assertEqualsMon "zfs c2 arg2" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL2_ARG2
-	assertEqualsMon "mkdir calls" "3" MKDIR_CALLS
-	assertEqualsMon "mkdir 1 arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
-	assertEqualsMon "mkdir 2 arg2" "${POT_FS_ROOT}/jails/new-pot/m/tmp" MKDIR_CALL2_ARG2
-	assertEqualsMon "mkdir 3 arg2" "${POT_FS_ROOT}/jails/new-pot/m/dev" MKDIR_CALL3_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir 1 arg2" "${POT_FS_ROOT}/jails/new-pot/m/tmp" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir 2 arg2" "${POT_FS_ROOT}/jails/new-pot/m/dev" MKDIR_CALL2_ARG2
 	assertEqualsMon "chmod calls" "1" CHMOD_CALLS
 	assertEqualsMon "chmod arg1" "1777" CHMOD_CALL1_ARG1
 	assertEqualsMon "chmod arg2" "${POT_FS_ROOT}/jails/new-pot/m/tmp" CHMOD_CALL1_ARG2
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_042()
@@ -274,17 +229,12 @@ test_cj_zfs_042()
 	assertEqualsMon "zfs calls" "1" ZFS_CALLS
 	assertEqualsMon "zfs arg1" "create" ZFS_CALL1_ARG1
 	assertEqualsMon "zfs arg2" "${POT_ZFS_ROOT}/jails/test-pot/m" ZFS_CALL1_ARG2
-	assertEqualsMon "mkdir calls" "3" MKDIR_CALLS
-	assertEqualsMon "mkdir 1 arg2" "${POT_FS_ROOT}/jails/test-pot/m" MKDIR_CALL1_ARG2
-	assertEqualsMon "mkdir 2 arg2" "${POT_FS_ROOT}/jails/test-pot/m/tmp" MKDIR_CALL2_ARG2
-	assertEqualsMon "mkdir 3 arg2" "${POT_FS_ROOT}/jails/test-pot/m/dev" MKDIR_CALL3_ARG2
+	assertEqualsMon "mkdir calls" "2" MKDIR_CALLS
+	assertEqualsMon "mkdir 1 arg2" "${POT_FS_ROOT}/jails/test-pot/m/tmp" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir 2 arg2" "${POT_FS_ROOT}/jails/test-pot/m/dev" MKDIR_CALL2_ARG2
 	assertEqualsMon "chmod calls" "1" CHMOD_CALLS
 	assertEqualsMon "chmod arg1" "1777" CHMOD_CALL1_ARG1
 	assertEqualsMon "chmod arg2" "${POT_FS_ROOT}/jails/test-pot/m/tmp" CHMOD_CALL1_ARG2
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/test-pot/m" STAT_CALL1_ARG3
 }
 
 test_cj_zfs_043()
@@ -303,13 +253,8 @@ test_cj_zfs_043()
 	assertEqualsMon "zfs c3 arg5" "${POT_ZFS_ROOT}" ZFS_CALL3_ARG5
 	assertEqualsMon "zfs c4 arg1" "receive" ZFS_CALL4_ARG1
 	assertEqualsMon "zfs c4 arg2" "${POT_ZFS_ROOT}/jails/new-pot/m" ZFS_CALL4_ARG2
-	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
-	assertEqualsMon "mkdir 1 arg2" "${POT_FS_ROOT}/jails/new-pot/m" MKDIR_CALL1_ARG2
+	assertEqualsMon "mkdir calls" "0" MKDIR_CALLS
 	assertEqualsMon "chmod calls" "0" CHMOD_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 setUp()

--- a/tests/rename3.sh
+++ b/tests/rename3.sh
@@ -6,17 +6,6 @@ zfs()
 	__monitor ZFS "$@"
 }
 
-mkdir()
-{
-	__monitor MKDIR "$@"
-}
-
-stat()
-{
-	__monitor STAT "$@"
-	echo 700
-}
-
 # UUT
 . ../share/pot/rename.sh
 
@@ -73,11 +62,6 @@ test_rn_zfs_001()
 	assertEqualsMon "zfs c8 arg2" "${POT_ZFS_ROOT}/jails/new-pot/custom" ZFS_CALL8_ARG2
 	assertEqualsMon "zfs c9 arg1" "mount" ZFS_CALL9_ARG1
 	assertEqualsMon "zfs c9 arg2" "${POT_ZFS_ROOT}/jails/new-pot/usr.local" ZFS_CALL9_ARG2
-	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot/m" STAT_CALL1_ARG3
 }
 
 test_rn_zfs_002()
@@ -101,11 +85,6 @@ test_rn_zfs_002()
 	assertEqualsMon "zfs c5 arg2" "${POT_ZFS_ROOT}/jails/new-pot-2" ZFS_CALL5_ARG2
 	assertEqualsMon "zfs c6 arg1" "mount" ZFS_CALL6_ARG1
 	assertEqualsMon "zfs c6 arg2" "${POT_ZFS_ROOT}/jails/new-pot-2/custom" ZFS_CALL6_ARG2
-	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot-2/m" STAT_CALL1_ARG3
 }
 
 test_rn_zfs_003()
@@ -129,12 +108,6 @@ test_rn_zfs_003()
 	assertEqualsMon "zfs c5 arg2" "${POT_ZFS_ROOT}/jails/new-pot-single" ZFS_CALL5_ARG2
 	assertEqualsMon "zfs c6 arg1" "mount" ZFS_CALL6_ARG1
 	assertEqualsMon "zfs c6 arg2" "${POT_ZFS_ROOT}/jails/new-pot-single/m" ZFS_CALL6_ARG2
-	assertEqualsMon "mkdir calls" "1" MKDIR_CALLS
-	assertEqualsMon "mkdir 1 arg2" "${POT_FS_ROOT}/jails/new-pot-single/m" MKDIR_CALL1_ARG2
-	assertEqualsMon "stat calls" "1" STAT_CALLS
-	assertEqualsMon "stat arg1" "-f" STAT_CALL1_ARG1
-	assertEqualsMon "stat arg2" "%Lp" STAT_CALL1_ARG2
-	assertEqualsMon "stat arg3" "${POT_FS_ROOT}/jails/new-pot-single/m" STAT_CALL1_ARG3
 }
 
 setUp()


### PR DESCRIPTION
Give /opt/pot 750 permissions, using POT_GROUP (defaults to group).

This was discussed in https://github.com/bsdpot/pot/issues/233#issuecomment-1265119627
and is the correct fix to #218.

Currently this does not check if /opt/pot has the expected permissions
when issuing pot commands, so we won't break existing installations
(we might want to enforce those in the future, right now it's only on init).

This also rolls back most of the changes from #218, only leaving in a
dedicated mountpoint mkdir function for the places where we already
did explicit mkdir before that change.

CI build running:
https://github.com/grembo/pot/actions/runs/3401453037/jobs/5656563834
