### PR TITLE
Add support for setting `allow.sysvipc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- set-attr: add jail attribute "raw_sockets" (#247)
+- set-attr: add jail attributes "raw_sockets", "sysvipc" (#247, #248)
 - import/export/prepare: support signing pots (#221)
 
 ### Changed

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -10,7 +10,7 @@ _POT_RO_ATTRIBUTES="to-be-pruned"
 _POT_NETWORK_TYPES="inherit alias public-bridge private-bridge"
 
 # not devfs handles separately
-_POT_JAIL_RW_ATTRIBUTES='enforce_statfs mount fdescfs linprocfs nullfs procfs tmpfs zfs raw_sockets children'
+_POT_JAIL_RW_ATTRIBUTES='enforce_statfs mount fdescfs linprocfs nullfs procfs tmpfs zfs raw_sockets sysvipc children'
 
 # N: arg name jail command, T: type of data, D: deafult value
 # devfs is always mounted
@@ -38,6 +38,9 @@ _POT_DEFAULT_zfs_D='NO'
 _POT_DEFAULT_raw_sockets_N='allow.raw_sockets'
 _POT_DEFAULT_raw_sockets_T='bool'
 _POT_DEFAULT_raw_sockets_D='NO'
+_POT_DEFAULT_sysvipc_N='allow.sysvipc'
+_POT_DEFAULT_sysvipc_T='bool'
+_POT_DEFAULT_sysvipc_D='NO'
 _POT_DEFAULT_children_N='children.max'
 _POT_DEFAULT_children_T='uint'
 _POT_DEFAULT_children_D='0'


### PR DESCRIPTION
As the title says. This is needed for PostgreSQL.