### PR TITLE
Output errors with pot root to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
+- pot-cmd: Output problems with pot root to stderr (#XXX)
 - version: Don't require pot root to exist to run version command (#253)
 
 ## [0.15.4] 2022-12-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- pot-cmd: Output problems with pot root to stderr (#XXX)
+- pot-cmd: Output problems with pot root to stderr (#254)
 - version: Don't require pot root to exist to run version command (#253)
 
 ## [0.15.4] 2022-12-15

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -1098,11 +1098,11 @@ pot-cmd()
 
 	if [ "$_cmd" != "init" ] && [ "$_cmd" != "de-init" ] && [ "$_cmd" != "version" ] ; then
 		if [ ! -d "$POT_FS_ROOT" ]; then
-			_error "$POT_FS_ROOT does not exist, please run 'pot init'"
+			>&2 _error "$POT_FS_ROOT does not exist, please run 'pot init'"
 			${EXIT} 1
 		fi
 		if [ ! -r "$POT_FS_ROOT" ]; then
-			_error "Current user has no read access to $POT_FS_ROOT"
+			>&2 _error "Current user has no read access to $POT_FS_ROOT"
 			${EXIT} 1
 		fi
 	fi


### PR DESCRIPTION
All errors should go to stderr, but this will be a larger change.