### PR TITLE
Remove trailing / for host folder

### DIFF
--- a/share/pot/mount-in.sh
+++ b/share/pot/mount-in.sh
@@ -185,7 +185,7 @@ pot-mount-in()
 			_fscomp="$OPTARG"
 			;;
 		d)
-			_dir="$OPTARG"
+			_dir="${OPTARG%/}"
 			;;
 		z)
 			_dset="$OPTARG"


### PR DESCRIPTION
Fixing in case, there is trailing / at the end of -d parameter.

```
pot mount-in -v -p foo -d /usr/local/etc/ -m /bar/etc
pot mount-in -v -p foo -d /usr/local/etc -m /bar/etc

```
This should throw an error for the second command since it's the same folder.