### PR TITLE
Remove basepath from mountpoint

### DIFF
--- a/share/pot/clone.sh
+++ b/share/pot/clone.sh
@@ -99,25 +99,7 @@ _cj_zfs()
 		fi
 		_debug "clone $_dset@$_snap into $_jdset/m"
 		zfs clone -o mountpoint="$_pdir/m" "$_dset@$_snap" "$_jdset/m"
-		touch "$_pdir/conf/fscomp.conf"
-		while read -r line ; do
-			_dset=$( echo "$line" | awk '{print $1}' )
-			_mnt_p=$( echo "$line" | awk '{print $2}' )
-			_opt=$( echo "$line" | awk '{print $3}' )
-			# ro components are replicated "as is"
-			if [ "$_opt" = ro ] ; then
-				_debug "$_dset ${_pdir}/${_mnt_p##"${_pbdir}"/} $_opt"
-				echo "$_dset ${_pdir}/${_mnt_p##"${_pbdir}"/} $_opt" >> "$_pdir/conf/fscomp.conf"
-			else
-				# managing fscomp datasets - the simple way - no clone support for fscomp
-				if [ "$_dset" != "${_dset##"${POT_ZFS_ROOT}"/fscomp}" ]; then
-					_debug "$_dset $_pdir/${_mnt_p##"${_pbdir}"/}"
-					echo "$_dset $_pdir/${_mnt_p##"${_pbdir}"/}" >> "$_pdir/conf/fscomp.conf"
-				else
-					_error "not able to manage $_dset"
-				fi
-			fi
-		done < "${_pbdir}/conf/fscomp.conf"
+		cp "${_pbdir}/conf/fscomp.conf" "$_pdir/conf/fscomp.conf"
 	elif [ "$_pb_type" = "multi" ]; then
 		# Create the root mountpoint
 		_create_pot_mountpoint "$_pdir/m"

--- a/share/pot/clone.sh
+++ b/share/pot/clone.sh
@@ -80,6 +80,7 @@ _cj_zfs()
 		rm -f "$_pdir/conf/fscomp.conf"
 	fi
 	_debug "Cloning $_potbase with snap $_snap"
+	_update_fscomp "$_potbase"
 	if [ "$_pb_type" = "single" ]; then
 		_dset="${_pbdset}/m"
 		if [ -z "$_snap" ]; then
@@ -112,8 +113,8 @@ _cj_zfs()
 			_opt=$( echo "$line" | awk '{print $3}' )
 			# ro components are replicated "as is"
 			if [ "$_opt" = ro ] ; then
-				_debug "$_dset ${_pdir}/${_mnt_p##"${_pbdir}"/} $_opt"
-				echo "$_dset ${_pdir}/${_mnt_p##"${_pbdir}"/} $_opt" >> "$_pdir/conf/fscomp.conf"
+				_debug "$_dset ${_mnt_p} $_opt"
+				echo "$_dset ${_mnt_p} $_opt" >> "$_pdir/conf/fscomp.conf"
 			else
 				# managing potbase datasets
 				if [ "$_dset" != "${_dset##"${_pbdset}"}" ]; then
@@ -139,17 +140,17 @@ _cj_zfs()
 						_debug "clone $_dset@$_snap into $_jdset/$_dname"
 						zfs clone -o mountpoint="$_pdir/$_dname" "$_dset@$_snap" "$_jdset/$_dname"
 						if [ -z "$_opt" ]; then
-							_debug "$_jdset/$_dname $_pdir/${_mnt_p##"${_pbdir}"/}"
-							echo "$_jdset/$_dname $_pdir/${_mnt_p##"${_pbdir}"/}" >> "$_pdir/conf/fscomp.conf"
+							_debug "$_jdset/$_dname ${_mnt_p}"
+							echo "$_jdset/$_dname ${_mnt_p}" >> "$_pdir/conf/fscomp.conf"
 						else
-							_debug "$_jdset/$_dname $_pdir/${_mnt_p##"${_pbdir}"/} $_opt"
-							echo "$_jdset/$_dname $_pdir/${_mnt_p##"${_pbdir}"/} $_opt" >> "$_pdir/conf/fscomp.conf"
+							_debug "$_jdset/$_dname ${_mnt_p} $_opt"
+							echo "$_jdset/$_dname ${_mnt_p} $_opt" >> "$_pdir/conf/fscomp.conf"
 						fi
 					fi
 				# managing fscomp datasets - the simple way - no clone support for fscomp
 				elif [ "$_dset" != "${_dset##"${POT_ZFS_ROOT}"/fscomp}" ]; then
-					_debug "$_dset $_pdir/${_mnt_p##"${_pbdir}"/}"
-					echo "$_dset $_pdir/${_mnt_p##"${_pbdir}"/}" >> "$_pdir/conf/fscomp.conf"
+					_debug "$_dset ${_mnt_p}"
+					echo "$_dset ${_mnt_p}" >> "$_pdir/conf/fscomp.conf"
 				else
 					_error "not able to manage $_dset"
 				fi

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -972,7 +972,7 @@ _is_fscomp_old()
 	_fsconf="${POT_FS_ROOT}/jails/$_pname/conf/fscomp.conf"
 	while read -r line; do
 		_mnt_p=$( echo "$line" | awk '{print $2}' )
-		_stripped_mnt_p="${_mnt_p##${POT_FS_ROOT}/jails/$_pname/m}"
+		_stripped_mnt_p="${_mnt_p##"${POT_FS_ROOT}/jails/$_pname/m"}"
 		if [ "$_stripped_mnt_p" != "$_mnt_p" ]; then
 			return 0 # true
 		fi
@@ -992,7 +992,7 @@ _update_fscomp()
 			_dset=$( echo "$line" | awk '{print $1}' )
 			_mnt_p=$( echo "$line" | awk '{print $2}' )
 			_opt=$( echo "$line" | awk '{print $3}' )
-			_stripped_mnt_p="${_mnt_p##${POT_FS_ROOT}/jails/$_pname/m}"
+			_stripped_mnt_p="${_mnt_p##"${POT_FS_ROOT}/jails/$_pname/m"}"
 			if [ -z "$_stripped_mnt_p" ]; then
 				_stripped_mnt_p="/"
 			fi

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -975,6 +975,7 @@ _pot_mount()
 	while read -r line ; do
 		_dset=$( echo "$line" | awk '{print $1}' )
 		_mnt_p=$( echo "$line" | awk '{print $2}' )
+		_mnt_p="${POT_FS_ROOT}/jails/$_pname/m$_mnt_p"
 		_opt=$( echo "$line" | awk '{print $3}' )
 		if [ "$_opt" = "zfs-remount" ]; then
 			# if the mountpoint doesn't exist, zfs will create it
@@ -1055,6 +1056,7 @@ _pot_umount()
 		while read -r line ; do
 			_dset=$( echo "$line" | awk '{print $1}' )
 			_mnt_p=$( echo "$line" | awk '{print $2}' )
+			_mnt_p="${POT_FS_ROOT}/jails/$_pname/m$_mnt_p"
 			_opt=$( echo "$line" | awk '{print $3}' )
 			if [ "$_opt" = "zfs-remount" ]; then
 				_node=${POT_FS_ROOT}/jails/$_pname/$(basename "$_dset")

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -1014,6 +1014,7 @@ _pot_mount()
 		_dset=$( echo "$line" | awk '{print $1}' )
 		_mnt_p=$( echo "$line" | awk '{print $2}' )
 		_mnt_p="${POT_FS_ROOT}/jails/$_pname/m$_mnt_p"
+		_mnt_p="${_mnt_p%/}"
 		_opt=$( echo "$line" | awk '{print $3}' )
 		if [ "$_opt" = "zfs-remount" ]; then
 			# if the mountpoint doesn't exist, zfs will create it
@@ -1095,6 +1096,7 @@ _pot_umount()
 			_dset=$( echo "$line" | awk '{print $1}' )
 			_mnt_p=$( echo "$line" | awk '{print $2}' )
 			_mnt_p="${POT_FS_ROOT}/jails/$_pname/m$_mnt_p"
+			_mnt_p=${_mnt_p%/}
 			_opt=$( echo "$line" | awk '{print $3}' )
 			if [ "$_opt" = "zfs-remount" ]; then
 				_node=${POT_FS_ROOT}/jails/$_pname/$(basename "$_dset")

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -965,6 +965,44 @@ _create_pot_mountpoint()
 }
 
 # $1 pot name
+_is_fscomp_old()
+{
+	local _pname _fsconf _mnt_p _stripped_mnt_p
+	_pname="$1"
+	_fsconf="${POT_FS_ROOT}/jails/$_pname/conf/fscomp.conf"
+	while read -r line; do
+		_mnt_p=$( echo "$line" | awk '{print $2}' )
+		_stripped_mnt_p="${_mnt_p##${POT_FS_ROOT}/jails/$_pname/m}"
+		if [ "$_stripped_mnt_p" != "$_mnt_p" ]; then
+			return 0 # true
+		fi
+	done < "$_fsconf"
+	return 1 # false
+}
+
+# $1 pot name
+_update_fscomp()
+{
+	local _pname _fsconf _mnt_p _stripped_mnt_p _dset _opt _tmpfile
+	_pname="$1"
+	if _is_fscomp_old "$_pname" ; then
+		_fsconf="${POT_FS_ROOT}/jails/$_pname/conf/fscomp.conf"
+		_tmpfile=$(mktemp "${POT_TMP:-/tmp}/fscomp.conf.${_pname}${POT_MKTEMP_SUFFIX}")
+		while read -r line; do
+			_dset=$( echo "$line" | awk '{print $1}' )
+			_mnt_p=$( echo "$line" | awk '{print $2}' )
+			_opt=$( echo "$line" | awk '{print $3}' )
+			_stripped_mnt_p="${_mnt_p##${POT_FS_ROOT}/jails/$_pname/m}"
+			if [ -z "$_stripped_mnt_p" ]; then
+				_stripped_mnt_p="/"
+			fi
+			${ECHO} "$_dset $_stripped_mnt_p $_opt" >> "$_tmpfile"
+		done < "$_fsconf"
+		mv "$_tmpfile" "$_fsconf"
+	fi
+}
+
+# $1 pot name
 _pot_mount()
 {
 	local _pname _dset _mnt_p _opt _node

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -1010,6 +1010,7 @@ _pot_mount()
 	if ! _is_pot "$_pname" ; then
 		return 1 # false
 	fi
+	_update_fscomp "$_pname"
 	while read -r line ; do
 		_dset=$( echo "$line" | awk '{print $1}' )
 		_mnt_p=$( echo "$line" | awk '{print $2}' )
@@ -1091,6 +1092,7 @@ _pot_umount()
 		_umount "$_jdir/m/proc"
 	fi
 	if [ -e "$_jdir/conf/fscomp.conf" ]; then
+		_update_fscomp "$_pname"
 		tail -r "$_jdir/conf/fscomp.conf" > "$_tmpfile"
 		while read -r line ; do
 			_dset=$( echo "$line" | awk '{print $1}' )

--- a/share/pot/create.sh
+++ b/share/pot/create.sh
@@ -271,24 +271,24 @@ _cj_conf()
 	if [ "$_type" = "multi" ]; then
 		case $_lvl in
 		0)
-			echo "$_bdset ${_jdir}/m"
-			echo "$_bdset/usr.local ${_jdir}/m/usr/local"
-			echo "$_bdset/custom ${_jdir}/m/opt/custom"
+			echo "$_bdset /"
+			echo "$_bdset/usr.local /usr/local"
+			echo "$_bdset/custom /opt/custom"
 			;;
 		1)
-			echo "$_bdset ${_jdir}/m ro"
-			echo "$_jdset/usr.local ${_jdir}/m/usr/local zfs-remount"
-			echo "$_jdset/custom ${_jdir}/m/opt/custom zfs-remount"
+			echo "$_bdset / ro"
+			echo "$_jdset/usr.local /usr/local zfs-remount"
+			echo "$_jdset/custom /opt/custom zfs-remount"
 			;;
 		2)
-			echo "$_bdset ${_jdir}/m ro"
+			echo "$_bdset / ro"
 			if [ "$_pblvl" -eq 1 ]; then
-				echo "$_pbdset/usr.local ${_jdir}/m/usr/local ro"
+				echo "$_pbdset/usr.local /usr/local ro"
 			else
 				_pbpb="$( _get_conf_var "$_potbase" pot.potbase )"
-				echo "${POT_ZFS_ROOT}/jails/$_pbpb/usr.local ${_jdir}/m/usr/local ro"
+				echo "${POT_ZFS_ROOT}/jails/$_pbpb/usr.local /usr/local ro"
 			fi
-			echo "$_jdset/custom ${_jdir}/m/opt/custom zfs-remount"
+			echo "$_jdset/custom /opt/custom zfs-remount"
 			;;
 		esac
 	fi

--- a/share/pot/mount-in.sh
+++ b/share/pot/mount-in.sh
@@ -144,11 +144,11 @@ _mount_dir()
 	_mnt_p="${3#/}"
 	_opt="${4}"
 	_pdir=$POT_FS_ROOT/jails/$_pname
-	_debug "add directory:$_dir mnt_p:$_pdir/m/$_mnt_p opt:$_opt"
+	_debug "add directory:$_dir mnt_p:/$_mnt_p opt:$_opt"
 	if [ -z "$_opt" ]; then
-		${ECHO} "$_dir $_pdir/m/$_mnt_p" >> "$_pdir/conf/fscomp.conf"
+		${ECHO} "$_dir /$_mnt_p" >> "$_pdir/conf/fscomp.conf"
 	else
-		${ECHO} "$_dir $_pdir/m/$_mnt_p $_opt" >> "$_pdir/conf/fscomp.conf"
+		${ECHO} "$_dir /$_mnt_p $_opt" >> "$_pdir/conf/fscomp.conf"
 	fi
 	if _is_pot_running "$_pname" ; then
 		if ! mount_nullfs -o "${_opt:-rw}" "$_dir" "$_pdir/m/$_mnt_p" ; then

--- a/share/pot/mount-in.sh
+++ b/share/pot/mount-in.sh
@@ -312,6 +312,7 @@ pot-mount-in()
 		return 1
 	fi
 	if ! _real_mnt_p="$(_mountpoint_validation "$_pname" "$_mnt_p" )" ; then
+		echo "$_real_mnt_p"
 		_error "The mountpoint is not valid!"
 		return 1
 	fi

--- a/share/pot/mount-out.sh
+++ b/share/pot/mount-out.sh
@@ -19,14 +19,14 @@ _is_mountpoint_used()
 {
 	local _pname _mnt_p _proot
 	_pname="$1"
-	_mnt_p="${2#/}"
+	_mnt_p="${2}"
 	_conf=$POT_FS_ROOT/jails/$_pname/conf/fscomp.conf
 	_proot=$POT_FS_ROOT/jails/$_pname/m
 	## spaces in this sequences of grep have been introduced to detect exact matches only
 	## a pattern like /mnt/test would match /mnt/test and /mnt/test2
 	## with those spaces we try be more precise in detecting the exact match
-	if grep -q " $_proot/$_mnt_p$" "$_conf" ||
-		grep -q " $_proot/$_mnt_p " "$_conf" ; then
+	if grep -q " $_mnt_p$" "$_conf" ||
+		grep -q " $_mnt_p " "$_conf" ; then
 		# mount point already used
 		return 0 # true
 	fi
@@ -47,10 +47,6 @@ _mountpoint_validation()
 	_mnt_p="$2"
 	_mpdir=$POT_FS_ROOT/jails/$_pname/m
 	_mounted=false # false
-	if ! _is_mountpoint_used "$_pname" "$_mnt_p" ; then
-		_error "The mount point $_mnt_p is not in use"
-		return 1 # false
-	fi
 	if ! _is_pot_running "$_pname" ; then
 		_mounted=true # true
 		if ! _pot_mount "$_pname" >/dev/null ; then
@@ -61,6 +57,10 @@ _mountpoint_validation()
 	_real_mnt=$( chroot "$_mpdir" /bin/realpath "$_mnt_p")
 	if eval $_mounted ; then
 		_pot_umount "$_pname" >/dev/null
+	fi
+	if ! _is_mountpoint_used "$_pname" "$_real_mnt" ; then
+		_error "The mount point $_mnt_p is not in use"
+		return 1 # false
 	fi
 	echo "$_real_mnt"
 	return 0 # true

--- a/share/pot/mount-out.sh
+++ b/share/pot/mount-out.sh
@@ -146,6 +146,7 @@ pot-mount-out()
 		return 1
 	fi
 	if ! _real_mnt_p="$(_mountpoint_validation "$_pname" "$_mnt_p" )" ; then
+		echo "$_real_mnt_p"
 		_error "The mountpoint is not valid!"
 		return 1
 	fi

--- a/share/pot/update-config.sh
+++ b/share/pot/update-config.sh
@@ -134,6 +134,9 @@ _update_one_pot()
 		_info "rss.cpuset has been deprecated; please use the more generic rss.cpus"
 		${SED} -i '' -e "/pot.rss.cpuset=.*/d" "$_conf"
 	fi
+
+	# remove the base pot path from mountpoints in fscomp.conf
+	_update_fscomp "$_pname"
 }
 
 _update_all_pots()

--- a/tests/clone2.sh
+++ b/tests/clone2.sh
@@ -74,6 +74,11 @@ _cj_undo_clone()
 	__monitor UNDO_CLONE "$@"
 }
 
+_update_fscomp()
+{
+	:
+}
+
 test_cj_zfs_001()
 {
 	_cj_zfs new-pot test-pot NO

--- a/tests/create3.sh
+++ b/tests/create3.sh
@@ -64,9 +64,9 @@ test_cj_conf_001()
 	# level 0
 	_cj_conf new-pot 11.1 inherit "" 0 inherit multi
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/bases/11.1/usr.local /tmp/jails/new-pot/m/usr/local" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/bases/11.1/custom /tmp/jails/new-pot/m/opt/custom" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 /" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/bases/11.1/usr.local /usr/local" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/bases/11.1/custom /opt/custom" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=0" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"
@@ -88,9 +88,9 @@ test_cj_conf_002()
 {
 	_cj_conf new-pot 11.1 inherit "" 1 inherit multi
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /tmp/jails/new-pot/m/usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /tmp/jails/new-pot/m/opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 / ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=1" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"
@@ -111,15 +111,14 @@ test_cj_conf_002()
 test_cj_conf_003()
 {
 	/bin/mkdir -p /tmp/jails/test-pot/conf
-	echo "zpot/bases/11.1 /tmp/jails/test-pot/m ro" >> /tmp/jails/test-pot/conf/fscomp.conf
-	echo "zpot/jails/test-pot/usr.local /tmp/jails/test-pot/m/usr/local zfs-remount" >> /tmp/jails/test-pot/conf/fscomp.conf
-	echo "zpot/jails/test-pot/custom /tmp/jails/test-pot/m/opt/custom zfs-remount" >> /tmp/jails/test-pot/conf/fscomp.conf
+	echo "zpot/bases/11.1 / ro" >> /tmp/jails/test-pot/conf/fscomp.conf
+	echo "zpot/jails/test-pot/usr.local /usr/local zfs-remount" >> /tmp/jails/test-pot/conf/fscomp.conf
+	echo "zpot/jails/test-pot/custom /opt/custom zfs-remount" >> /tmp/jails/test-pot/conf/fscomp.conf
 	_cj_conf new-pot 11.1 inherit "" 1 inherit multi "" test-pot
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /tmp/jails/new-pot/m/usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /tmp/jails/new-pot/m/opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/test-pot/usr.local /tmp/jails/test-pot/m/usr/local zfs-remount" "$(sed '2!d' /tmp/jails/test-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 / ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=1" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"
@@ -140,15 +139,14 @@ test_cj_conf_003()
 test_cj_conf_004()
 {
 	/bin/mkdir -p /tmp/jails/test-pot/conf
-	echo "zpot/bases/11.1 /tmp/jails/test-pot/m ro" >> /tmp/jails/test-pot/conf/fscomp.conf
-	echo "zpot/jails/test-pot/usr.local /tmp/jails/test-pot/m/usr/local zfs-remount" >> /tmp/jails/test-pot/conf/fscomp.conf
-	echo "zpot/jails/test-pot/custom /tmp/jails/test-pot/m/opt/custom zfs-remount" >> /tmp/jails/test-pot/conf/fscomp.conf
+	echo "zpot/bases/11.1 / ro" >> /tmp/jails/test-pot/conf/fscomp.conf
+	echo "zpot/jails/test-pot/usr.local /usr/local zfs-remount" >> /tmp/jails/test-pot/conf/fscomp.conf
+	echo "zpot/jails/test-pot/custom /opt/custom zfs-remount" >> /tmp/jails/test-pot/conf/fscomp.conf
 	_cj_conf new-pot 11.1 inherit "" 2 inherit multi "" test-pot
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/test-pot/usr.local /tmp/jails/new-pot/m/usr/local ro" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /tmp/jails/new-pot/m/opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/test-pot/usr.local /tmp/jails/test-pot/m/usr/local" "$(sed '2!d' /tmp/jails/test-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 / ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/jails/test-pot/usr.local /usr/local ro" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=2" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"
@@ -169,9 +167,9 @@ test_cj_conf_005()
 {
 	_cj_conf new-pot 11.1 inherit "" 2 inherit multi "" test-pot-2
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/test-pot/usr.local /tmp/jails/new-pot/m/usr/local ro" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /tmp/jails/new-pot/m/opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 / ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/jails/test-pot/usr.local /usr/local ro" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=2" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"
@@ -193,9 +191,9 @@ test_cj_conf_006()
 {
 	_cj_conf new-pot 11.1 public-bridge 10.1.2.3 1 inherit multi
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /tmp/jails/new-pot/m/usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /tmp/jails/new-pot/m/opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 / ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=1" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"
@@ -217,9 +215,9 @@ test_cj_conf_007()
 {
 	_cj_conf new-pot 11.1 inherit "" 1 pot multi
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /tmp/jails/new-pot/m/usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /tmp/jails/new-pot/m/opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 / ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=1" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"
@@ -242,9 +240,9 @@ test_cj_conf_008()
 {
 	_cj_conf new-pot 11.1 public-bridge 10.1.2.3 1 pot multi
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /tmp/jails/new-pot/m/usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /tmp/jails/new-pot/m/opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 / ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=1" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"
@@ -267,9 +265,9 @@ test_cj_conf_009()
 {
 	_cj_conf new-pot 11.1 alias 10.1.2.3 1 pot multi
 	assertEquals "return code" "0" "$?"
-	assertEquals "fscomp args1" "zpot/bases/11.1 /tmp/jails/new-pot/m ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /tmp/jails/new-pot/m/usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
-	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /tmp/jails/new-pot/m/opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args1" "zpot/bases/11.1 / ro" "$(sed '1!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args2" "zpot/jails/new-pot/usr.local /usr/local zfs-remount" "$(sed '2!d' /tmp/jails/new-pot/conf/fscomp.conf)"
+	assertEquals "fscomp args3" "zpot/jails/new-pot/custom /opt/custom zfs-remount" "$(sed '3!d' /tmp/jails/new-pot/conf/fscomp.conf)"
 	assertEquals "pot.level" "pot.level=1" "$(grep ^pot.level /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "pot.base" "pot.base=11.1" "$(grep ^pot.base /tmp/jails/new-pot/conf/pot.conf)"
 	assertEquals "osrelease" "osrelease=\"11.1-RELEASE\"" "$(grep ^osrelease /tmp/jails/new-pot/conf/pot.conf)"


### PR DESCRIPTION
There are a couple of things that changed here

1. update the mount method to append the actual jail root path
2. update how mount-in stores the path without prefixing with the jail root path
3. fix clone to copy file since no need to fix anything

The missing bit is probably to remove two lines from rename command because no replacement is required. 

I haven't checked if anything breaks with the datasets.

But the process of creating pot, with some mounts, exporting it, and then import with additional clone makes everything as it should be.

This fixes #257 