### PR TITLE
start: Add support for pf hook script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- start: Add custom pf rule configuration hook, POT_EXPORT_PORTS_PF_RULES_HOOK (#273)
+
 ## [0.15.5] 2023-06-29
 ### Added
 - set-attr: Add support for setting devfs_ruleset (#270)

--- a/etc/pot/pot.default.conf
+++ b/etc/pot/pot.default.conf
@@ -46,6 +46,17 @@ POT_DNS_NAME=dns
 # IP of the DNS
 POT_DNS_IP=10.192.0.2
 
+# If not empty, this script will be called by pot and the pf rules
+# returned on stdout will be loaded into "pot-rdr/anchor" instead
+# of those which pot would usually create. This also skips
+# creation of netcat-based localhost-tunnels.
+# Only works with IPv4 at the moment.
+#
+# Parameters sent to the script are:
+# POT_EXTIF BRIDGE POT_NETWORK POT_GATEWAY proto host_port pot_ip pot_port
+# Example:
+# igb0 bridge1 10.192.0.0/10 10.192.0.1 tcp 32732 10.192.0.10 80
+POT_EXPORT_PORTS_PF_RULES_HOOK=
 # VPN support
 
 # name of the tunnel network interface


### PR DESCRIPTION
By setting POT_EXPORT_PORTS_PF_RULES_HOOK, the user has fine grained control over how pf rules are setup.

This also skips creating netcat pipes.

Example scripts making use of this will come in the future.