### PR TITLE
New attribute to control pot stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- set-attr/stop: Add attributes exec_stop and stop_timeout (#275)
+
+### Fixed
+- start: Fix setting of nullfs attribute
+
 ## [0.15.6] 2023-09-29
 ### Added
 - start: Add custom pf rule configuration hook, POT_EXPORT_PORTS_PF_RULES_HOOK (#273)

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -10,7 +10,7 @@ _POT_RO_ATTRIBUTES="to-be-pruned"
 _POT_NETWORK_TYPES="inherit alias public-bridge private-bridge"
 
 # not devfs handles separately
-_POT_JAIL_RW_ATTRIBUTES='enforce_statfs mount fdescfs linprocfs nullfs procfs tmpfs zfs raw_sockets sysvshm sysvsem sysvmsg children mlock devfs_ruleset'
+_POT_JAIL_RW_ATTRIBUTES='enforce_statfs mount fdescfs linprocfs nullfs procfs tmpfs zfs raw_sockets sysvshm sysvsem sysvmsg children mlock devfs_ruleset exec_stop stop_timeout'
 
 # N: arg name jail command, T: type of data, D: deafult value
 # devfs is always mounted
@@ -23,9 +23,9 @@ _POT_DEFAULT_fdescfs_D='NO'
 _POT_DEFAULT_linprocfs_N='allow.mount.linprocfs'
 _POT_DEFAULT_linprocfs_T='bool'
 _POT_DEFAULT_linprocfs_D='NO'
-_POT_DEFAULT_nullcfs_N='allow.mount.nullfs'
-_POT_DEFAULT_nullcfs_T='bool'
-_POT_DEFAULT_nullcfs_D='NO'
+_POT_DEFAULT_nullfs_N='allow.mount.nullfs'
+_POT_DEFAULT_nullfs_T='bool'
+_POT_DEFAULT_nullfs_D='NO'
 _POT_DEFAULT_procfs_N='mount.procfs'
 _POT_DEFAULT_procfs_T='bool'
 _POT_DEFAULT_procfs_D='NO'
@@ -56,6 +56,12 @@ _POT_DEFAULT_devfs_ruleset_D='4'
 _POT_DEFAULT_mlock_N='allow.mlock'
 _POT_DEFAULT_mlock_T='bool'
 _POT_DEFAULT_mlock_D='NO'
+_POT_DEFAULT_exec_stop_N='exec.stop'
+_POT_DEFAULT_exec_stop_T='string'
+_POT_DEFAULT_exec_stop_D=''
+_POT_DEFAULT_stop_timeout_N='stop.timeout'
+_POT_DEFAULT_stop_timeout_T='uint'
+_POT_DEFAULT_stop_timeout_D='10'
 # 0:everything, 1:chroot+below(poudriere), 2:just chroot(normal jail)
 _POT_DEFAULT_enforce_statfs_N='enforce_statfs'
 _POT_DEFAULT_enforce_statfs_T='uint'
@@ -508,6 +514,18 @@ _get_conf_var()
 	_cdir="${POT_FS_ROOT}/jails/$_pname/conf"
 	_var="$2"
 	_value="$( grep "^$_var=" "$_cdir/pot.conf" | tr -d ' \t"' | cut -f2 -d'=' )"
+	echo "$_value"
+}
+
+# $1 pot name
+# $2 var name
+_get_conf_var_string()
+{
+	local _pname _cdir _var _value
+	_pname="$1"
+	_cdir="${POT_FS_ROOT}/jails/$_pname/conf"
+	_var="$2"
+	_value="$( grep "^$_var=" "$_cdir/pot.conf" | cut -f2 -d'=' )"
 	echo "$_value"
 }
 

--- a/share/pot/set-attribute.sh
+++ b/share/pot/set-attribute.sh
@@ -76,6 +76,21 @@ _set_uint_attribute()
 # $1 pot name
 # $2 attribute name
 # $3 value
+_set_string_attribute()
+{
+	local _pname _value _cdir
+	_pname=$1
+	_attr=$2
+	_value=$3
+
+	_cdir="$POT_FS_ROOT/jails/$_pname/conf"
+	${SED} -i '' -e "/^pot.attr.$_attr=.*/d" "$_cdir/pot.conf"
+	echo "pot.attr.$_attr=$_value" >> "$_cdir/pot.conf"
+}
+
+# $1 pot name
+# $2 attribute name
+# $3 value
 _set_sysvopt_attribute()
 {
 	local _pname _value _cdir
@@ -193,6 +208,9 @@ pot-set-attribute()
 				;;
 			(uint)
 				_cmd=_set_uint_attribute
+				;;
+			(string)
+				_cmd=_set_string_attribute
 				;;
 			(sysvopt)
 				_cmd=_set_sysvopt_attribute

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -635,7 +635,7 @@ _js_start()
 	_info "Starting the pot $_pname"
 	# execute command
 	eval "set -- $_param"
-	echo "$@"
+	_debug "Pot $_pname jail params are: $*"
 	jail -c "$@" exec.start="sh -c 'sleep 1234&'"
 
 	if [ -e "$_confdir/pot.conf" ] && _is_pot_prunable "$_pname" ; then

--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -36,6 +36,7 @@ _js_cpu_rebalance()
 _js_stop()
 {
 	local _pname _pdir _epaira _epaira_ifs _ip _aname _from_start
+	local _exec_stop _stop_timeout
 	_pname="$1"
 	_from_start="$2"
 	_epaira_ifs="$3"
@@ -51,7 +52,22 @@ _js_stop()
 			)
 		fi
 		_debug "Stop the pot $_pname"
-		jail -q -r "$_pname"
+
+		_exec_stop="$(_get_conf_var_string "$_pname" "pot.attr.exec_stop")"
+		_stop_timeout="$(_get_conf_var "$_pname" "pot.attr.stop_timeout")"
+		(
+			echo "$_pname {"
+			if [ -n "$_exec_stop" ]; then
+				printf "  %s=%s;\n" "exec.stop" \
+				       "$(echo "$_exec_stop" | sed 's/["\]/\\&/g; s/.*/"&"/')"
+
+				# balance quotes for cheap syntax highlighting editors'
+			fi
+			if [ -n "$_stop_timeout" ]; then
+				printf "  %s=%s;\n" "stop.timeout" "$_stop_timeout"
+			fi
+			echo "}"
+		) | jail -f- -q -r "$_pname"
 	fi
 	# those are clean up operations for a pot already stopped
 	if [ -n "$_epaira_ifs" ]; then


### PR DESCRIPTION
By setting exec_stop and stop_timeout (which correspond to
jail(8) attributes exec.stop and stop.timeout), the user
has better control over shutting down a pot.

For "fat" pots this could mean setting

    pot set-attr -A exec_stop -V "/bin/sh /etc/rc.shutdown jail"

for light pots (like nomad controlled using tinirc), this could
point to a simple script that make sure the wrapped process is
stopped gracefully and, in case multiple processes are running
inseide of the pot, make sure they're terminated in the correct
order.

Also:
- Fix a typo that made the nullfs attribute not work.
- Make pot start use _save_params, which makes wrapping
  attributes safer and therefore allows to remove
  a shellcheck exemption.