### PR TITLE
Store tinirc.pid on start, truncate tinirc on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- tinirc: Write tinirc's pid to /tmp/tinirc.pid (#277)
 - set-attr/stop: Add attributes exec_stop and stop_timeout (#275)
 
 ### Fixed
+- tinirc: Overwrite tinirc on start instead of appending to an existing file (#277)
 - start: Fix setting of nullfs attribute
 
 ## [0.15.6] 2023-09-29

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -506,7 +506,9 @@ _js_start()
 		else
 			prec=35
 		fi
-		cat >>"${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc" <<-EOT
+		cat >"${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc" <<-EOT
+		# created automatically by pot, changes will be overwritten
+		echo \$\$ >/tmp/tinirc.pid
 		if sysctl -n kern.features.inet6 >/dev/null 2>&1; then
 		        ip6addrctl flush >/dev/null 2>&1
 		        ip6addrctl install /dev/stdin <<EOF


### PR DESCRIPTION
Storing the pid (which will become the pid of the process tinirc starts)
makes writing stop scripts easier.

Picked /tmp as the location, as /var/run might not be available in slim
no-rc images.

Fixed a bug where an existing copy of tinirc would be appended to,
meaning that none of the pot's settings would actually be applied.