### PR TITLE
Ignore pot status files that predate boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - start: Fix setting of nullfs attribute
+- set-status: Ignore status files that predate system boot (#278)
 
 ## [0.15.6] 2023-09-29
 ### Added

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -177,6 +177,11 @@ _save_params () {
 	echo " "
 }
 
+# get system boot time in seconds since the epoch
+_get_system_uptime() {
+	sysctl -n kern.boottime | sed -e 's/.*[^u]sec = \([0-9]*\).*$/\1/'
+}
+
 # validate some values of the configuration files
 # $1 quiet / no _error messages are emitted
 _conf_check()

--- a/share/pot/set-status.sh
+++ b/share/pot/set-status.sh
@@ -21,13 +21,22 @@ set-status-help()
 # $1 pot name
 _get_status()
 {
-	local _pname _status_file
+	local _pname _status_file _uptime _mod_time
 	_pname="$1"
 	_status_file="${POT_TMP:-/tmp}/pot_status_${_pname}"
 
 	if [ ! -e "$_status_file" ]; then
 		return
 	fi
+
+	_mod_time=$(stat -f "%m" "$_status_file")
+	_uptime=$(_get_system_uptime)
+
+	if [ "$_uptime" -gt "$_mod_time" ]; then
+		>&2 _debug "Ignoring oudated status file $_status_file of pot $_pname"
+		return
+	fi
+
 	_value="$(grep "^pot.status=" "$_status_file" | tail -n 1 \
 		|tr -d ' \t"' | cut -f2 -d'=' )"
 	echo "$_value"


### PR DESCRIPTION
Simple check based on the system's uptime.

This makes sure pots running before the machine was rebooted
won't affect pot's state model.
