### PR TITLE
Find bridge interfaces by interface group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - start: Fix setting of nullfs attribute
 - set-status: Ignore status files that predate system boot (#278)
 - set-status: Forward verbosity flags (#279)
+- network: Find bridge interfaces by interface group, this allows custom bridge names (#282)
 
 ## [0.15.6] 2023-09-29
 ### Added

--- a/share/pot/network.sh
+++ b/share/pot/network.sh
@@ -10,7 +10,7 @@ _pot_bridge()
 _pot_bridge_ipv4()
 {
 	local _bridges
-	_bridges=$( ifconfig | grep ^bridge | cut -f1 -d':' )
+	_bridges=$( ifconfig -g bridge )
 	if [ -z "$_bridges" ]; then
 		return
 	fi
@@ -26,7 +26,7 @@ _pot_bridge_ipv4()
 _pot_bridge_ipv6()
 {
 	local _bridges
-	_bridges=$( ifconfig | grep ^bridge | cut -f1 -d':' )
+	_bridges=$( ifconfig -g bridge )
 	if [ -z "$_bridges" ]; then
 		return
 	fi
@@ -43,7 +43,7 @@ _private_bridge()
 {
 	local _bridges _bridge _bridge_ip
 	_bridge="$1"
-	_bridges=$( ifconfig | grep ^bridge | cut -f1 -d':' )
+	_bridges=$( ifconfig -g bridge )
 	if [ -z "$_bridges" ]; then
 		return
 	fi

--- a/tests/network1.sh
+++ b/tests/network1.sh
@@ -61,6 +61,13 @@ bridge2: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
 	root id 00:00:00:00:00:00 priority 32768 ifcost 0 port 0
 EOF--
 		return 0 # true
+	elif [ "$1" = "-g" ] && [ "$2" = "bridge" ]; then
+		cat << EOF--
+bridge0
+bridge1
+bridge2
+EOF--
+		return 0 # true
 	elif [ "$1" = "bridge0" ]; then
 		cat << EOF--
 bridge0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500


### PR DESCRIPTION
This allows users to give their bridges custom names.
We might make use of this as well in the future
(think $POT_BRIDGE_NAME).