### PR TITLE
New global config to isolate vnet pots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - tinirc: Write tinirc's pid to /tmp/tinirc.pid (#277)
 - set-attr/stop: Add attributes exec_stop and stop_timeout (#275)
+- vnet: Add global configuration POT_ISOLATE_VNET_POTS to prevent direct traffic between VNET pots (#283)
 
 ### Fixed
 - tinirc: Overwrite tinirc on start instead of appending to an existing file (#277)

--- a/etc/pot/pot.conf.sample
+++ b/etc/pot/pot.conf.sample
@@ -43,6 +43,9 @@
 # POT_NETWORK_vlan20=192.168.100.0/24
 # POT_NETWORK_vlan50=10.50.50.0/24
 
+# Do not allow bridge-based pots to forward traffic to each other
+# POT_ISOLATE_VNET_POTS=true
+
 # DNS on the Internal Virtual Network
 
 # name of the pot running the DNS

--- a/etc/pot/pot.default.conf
+++ b/etc/pot/pot.default.conf
@@ -46,6 +46,10 @@ POT_DNS_NAME=dns
 # IP of the DNS
 POT_DNS_IP=10.192.0.2
 
+# If set to true, isolate pot vnet bridge members
+# (by using `ifconfig <bridgeif> private <memberif>`, see ifconfig(8))
+POT_ISOLATE_VNET_POTS=false
+
 # If not empty, this script will be called by pot and the pf rules
 # returned on stdout will be loaded into "pot-rdr/anchor" instead
 # of those which pot would usually create. This also skips

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -182,6 +182,24 @@ _get_system_uptime() {
 	sysctl -n kern.boottime | sed -e 's/.*[^u]sec = \([0-9]*\).*$/\1/'
 }
 
+# check if the argument is a valid boolean value
+# if valid, it returns true and it echo a normalized version of the boolean value (YES/NO)
+# if not valid, it return false
+_normalize_true_false() {
+	case $1 in
+		[Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|[Oo][Nn])
+			echo YES
+			return 0 # true
+			;;
+		[Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff])
+			echo NO
+			return 0 # true
+			;;
+		*)
+			return 1 # false
+	esac
+}
+
 # validate some values of the configuration files
 # $1 quiet / no _error messages are emitted
 _conf_check()

--- a/share/pot/set-attribute.sh
+++ b/share/pot/set-attribute.sh
@@ -16,24 +16,6 @@ set-attribute-help()
 	EOH
 }
 
-# check if the argument is a valid boolean value
-# if valid, it returns true and it echo a normalized version of the boolean value (YES/NO)
-# if not valid, it return false
-_normalize_true_false() {
-	case $1 in
-		[Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|[Oo][Nn])
-			echo YES
-			return 0 # true
-			;;
-		[Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff])
-			echo NO
-			return 0 # true
-			;;
-		*)
-			return 1 # false
-	esac
-}
-
 # $1 pot name
 # $2 attribute name
 # $3 value


### PR DESCRIPTION
This new global setting called `POT_ISOLATE_VNET_POTS` sets bridge member epaira interfaces to be private, preventing them from forwarding traffic to each other. This helps with overall security, but (primarily) makes sure that pots in larger nomad clusters don't talk to each other using direct communication instead of published (natted) endpoints.

This could be a more fine-grained per pot setting in the future, in our setups we only ever needed a global setting decided by the infrastructure operator (so, e.g., in the nomad cluster, everything uses this setting, whereas in the more static part forming the infrastructure the nomad cluster relies on, direct communication between pots is wanted) and changing it per pot would be a disadvantage - hence this implementation.