### PR TITLE
Make init/de-init less intrusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - tinirc: Write tinirc's pid to /tmp/tinirc.pid (#277)
 - set-attr/stop: Add attributes exec_stop and stop_timeout (#275)
+- init/de-init: Add flag "-m" to be minimally intrusive, add flag -p to specify pf file (#284)
+- init: Add flag -s to not alter syslogd settings, deprecate flag -f pf_file, as it is replaced by -p (#284)
 
 ### Fixed
 - tinirc: Overwrite tinirc on start instead of appending to an existing file (#277)

--- a/share/pot/init.sh
+++ b/share/pot/init.sh
@@ -8,26 +8,38 @@
 init-help()
 {
 	cat <<-"EOH"
-	pot init [-hv] [-f pf_file]
-	  -f pf_file : write pot anchors to this file (empty to skip),
-	               defaults to result of `sysrc -n pf_rules`
+	pot init [-hmsv] [-p pf_file]
 	  -h print this help
+	  -m minimal modifications (alias for `-sp ''`)
+	  -p pf_file : write pot anchors to this file (empty to skip),
+	               defaults to result of `sysrc -n pf_rules`
+	  -f pf_file : alias for -p pf_file (deprecated)
+	  -s do not alter syslogd config
 	  -v verbose
 	EOH
 }
 
 pot-init()
 {
-	local pf_file dataset
-	pf_file="$(sysrc -n pf_rules)"
+	local _pf_file _dataset _skip_alter_syslog
+	_pf_file="$(sysrc -n pf_rules)"
+	_skip_alter_syslog=
 	OPTIND=1
-	while getopts "hvf:" _o ; do
+	while getopts "hmsvf:p:" _o ; do
 		case "$_o" in
-		f)	pf_file="$OPTARG"
+		f|p)
+			_pf_file="$OPTARG"
 			;;
 		h)
 			init-help
 			${EXIT} 0
+			;;
+		m)
+			_pf_file=""
+			_skip_alter_syslog="YES"
+			;;
+		s)
+			_skip_alter_syslog="YES"
 			;;
 		v)
 			_POT_VERBOSITY=$(( _POT_VERBOSITY + 1))
@@ -73,14 +85,14 @@ pot-init()
 	chown root:"${POT_GROUP:-pot}" "${POT_FS_ROOT}" || ${EXIT} 1
 
 	# create mandatory datasets
-	for dataset in bases jails fscomp; do
-		if ! _zfs_dataset_valid "${POT_ZFS_ROOT}/$dataset" ; then
-			_debug "creating ${POT_ZFS_ROOT}/$dataset"
-			zfs create "${POT_ZFS_ROOT}/$dataset" || ${EXIT} 1
+	for _dataset in bases jails fscomp; do
+		if ! _zfs_dataset_valid "${POT_ZFS_ROOT}/$_dataset" ; then
+			_debug "creating ${POT_ZFS_ROOT}/$_dataset"
+			zfs create "${POT_ZFS_ROOT}/$_dataset" || ${EXIT} 1
 		fi
-		if ! _zfs_mounted "${POT_ZFS_ROOT}/$dataset"; then
-			_debug "mounting ${POT_ZFS_ROOT}/$dataset"
-			zfs mount "${POT_ZFS_ROOT}/$dataset" || ${EXIT} 1
+		if ! _zfs_mounted "${POT_ZFS_ROOT}/$_dataset"; then
+			_debug "mounting ${POT_ZFS_ROOT}/$_dataset"
+			zfs mount "${POT_ZFS_ROOT}/$_dataset" || ${EXIT} 1
 		fi
 	done
 	if ! _zfs_exist "${POT_ZFS_ROOT}/cache" "${POT_CACHE}" ; then
@@ -91,10 +103,12 @@ pot-init()
 	fi
 	# create the bridges folder
 	mkdir -p "${POT_FS_ROOT}/bridges"
-	# create mandatory directories for logs
-	mkdir -p /usr/local/etc/syslog.d
-	mkdir -p /usr/local/etc/newsyslog.conf.d
-	mkdir -p /var/log/pot
+	if [ "$_skip_alter_syslog" != "YES" ]; then
+		# create mandatory directories for logs
+		mkdir -p /usr/local/etc/syslog.d
+		mkdir -p /usr/local/etc/newsyslog.conf.d
+		mkdir -p /var/log/pot
+	fi
 
 	if ! _is_pot_tmp_dir ; then
 		_error "The POT_TMP directory has not been created - aborting"
@@ -127,31 +141,33 @@ pot-init()
 		fi
 	done
 
-	if [ -w /etc/rc.conf ]; then
-		echo "Creating a backup of your /etc/rc.conf"
-		cp -v /etc/rc.conf /etc/rc.conf.bkp-pot
+	if [ "$_skip_alter_syslog" != "YES" ]; then
+		if [ -w /etc/rc.conf ]; then
+			echo "Creating a backup of your /etc/rc.conf"
+			cp -v /etc/rc.conf /etc/rc.conf.bkp-pot
+		fi
+		# add proper syslogd flags and restart it
+		sysrc -q syslogd_flags="-b 127.0.0.1 -b $POT_GATEWAY -a $POT_NETWORK"
+		# service syslogd restart
 	fi
-	# add proper syslogd flags and restart it
-	sysrc -q syslogd_flags="-b 127.0.0.1 -b $POT_GATEWAY -a $POT_NETWORK"
-	# service syslogd restart
 
 	# Add pot anchors if needed
-	if [ -n "$pf_file" ]; then
-		if [ -r "$pf_file" ] && [ "$(grep -c '^nat-anchor pot-nat$' "$pf_file" )" -eq 1 ] && [ "$(grep -c '^rdr-anchor "pot-rdr/\*"$' "$pf_file" )" -eq 1 ] ; then
+	if [ -n "$_pf_file" ]; then
+		if [ -r "$_pf_file" ] && [ "$(grep -c '^nat-anchor pot-nat$' "$_pf_file" )" -eq 1 ] && [ "$(grep -c '^rdr-anchor "pot-rdr/\*"$' "$_pf_file" )" -eq 1 ] ; then
 			_debug "pf already properly configured"
 		else
-			if [ -w "$pf_file" ]; then
-				echo "Creating a backup of your $pf_file"
-				cp -v "$pf_file" "$pf_file".bkp-pot
+			if [ -w "$_pf_file" ]; then
+				echo "Creating a backup of your $_pf_file"
+				cp -v "$_pf_file" "$_pf_file".bkp-pot
 				# delete incomplete/broken ancory entries - just in case
-				sed -i '' '/^nat-anchor pot-nat$/d' "$pf_file"
-				sed -i '' '/^rdr-anchor "pot-rdr\/\*"$/d' "$pf_file"
+				sed -i '' '/^nat-anchor pot-nat$/d' "$_pf_file"
+				sed -i '' '/^rdr-anchor "pot-rdr\/\*"$/d' "$_pf_file"
 			else
-				touch "$pf_file"
+				touch "$_pf_file"
 			fi
-			echo "auto-magically editing your $pf_file"
-			printf "%s\n" 0a "nat-anchor pot-nat" "rdr-anchor \"pot-rdr/*\"" . x | ex "$pf_file"
-			echo "Please, check that your PF configuration file $pf_file is still valid!"
+			echo "auto-magically editing your $_pf_file"
+			printf "%s\n" 0a "nat-anchor pot-nat" "rdr-anchor \"pot-rdr/*\"" . x | ex "$_pf_file"
+			echo "Please, check that your PF configuration file $_pf_file is still valid and reload it!"
 		fi
 	else
 		_debug "pf configuration skipped"


### PR DESCRIPTION
This adds the flag "-m" to be minimally intrusive. Also allows de-init to use "-p pf_file" to specify the firewall rulesets (this way it's symmetrical to init).

Rename "-f pf_file" to "-p pf_file" in init (as "-f" was already taken in de-init), but keep "-f" as an alias for the time being.

Add flag "-s" to init (do not alter syslogd configuration).

Some minor cleanup of variable names while there.

Fixes #85