### PR TITLE
import/prepare: Setting a default signature public key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unrelease
+### Added
+- import/prepare: Support setting a default signature public key to verify pot signature (#296)
+
 ## [0.16.0] 2023-12-30
 ### Added
 - tinirc: Write tinirc's pid to /tmp/tinirc.pid (#277)

--- a/etc/pot/pot.conf.sample
+++ b/etc/pot/pot.conf.sample
@@ -54,6 +54,10 @@
 # IP of the DNS
 # POT_DNS_IP=10.192.0.2
 
+# Path to default public key to verify pot signatures using signify(1)
+# on import/prepare - can be overridden using `-C pubkey`.
+# POT_DEFAULT_SIGNATURE_PUBKEY=/usr/local/etc/pot/sign_key.pub
+
 # VPN support
 
 # name of the tunnel network interface

--- a/etc/pot/pot.default.conf
+++ b/etc/pot/pot.default.conf
@@ -63,6 +63,10 @@ POT_ISOLATE_VNET_POTS=false
 POT_EXPORT_PORTS_PF_RULES_HOOK=
 # VPN support
 
+# Path to default public key to verify pot signatures using signify(1)
+# on import/prepare - can be overridden using `-C pubkey`.
+POT_DEFAULT_SIGNATURE_PUBKEY=
+
 # name of the tunnel network interface
 POT_VPN_EXTIF=
 POT_VPN_NETWORKS=

--- a/share/pot/import.sh
+++ b/share/pot/import.sh
@@ -161,7 +161,7 @@ pot-import()
 	_rpname=
 	_tag=
 	_URL=
-	_sign_pubkey=
+	_sign_pubkey="$POT_DEFAULT_SIGNATURE_PUBKEY"
 	local _meta _dep_pname_tag _dep_snap _dep_pname _dep_tag _dep_origin
 	local _filename
 

--- a/share/pot/prepare.sh
+++ b/share/pot/prepare.sh
@@ -48,7 +48,7 @@ pot-prepare()
 	_bridge_name=
 	_cmd=
 	_dns=
-	_sign_pubkey=
+	_sign_pubkey="$POT_DEFAULT_SIGNATURE_PUBKEY"
 	OPTIND=1
 	while getopts "hvp:U:t:c:e:a:n:sN:i:B:S:d:C:" _o ; do
 		case "$_o" in


### PR DESCRIPTION
This allows to set a global default key to check against, which can still be overridden by `-C pubkey` in import/prepare.

This is especially useful when using the nomad-pot-plugin, as it allows to limit the pot images to run on the cluster to those which were signed by a trusted pot provider.